### PR TITLE
DSE Support

### DIFF
--- a/frontend/cstar_perf/frontend/server/model.py
+++ b/frontend/cstar_perf/frontend/server/model.py
@@ -403,7 +403,7 @@ class Model(object):
 
     def add_cluster_product(self, cluster, product):
         session = self.get_session()
-        session.execute(self.__prepared_statements['add_cluster_product'], (product, cluster))
+        session.execute(self.__prepared_statements['add_cluster_product'], ([product], cluster))
 
     ################################################################################
     #### API Keys:

--- a/frontend/cstar_perf/frontend/server/model.py
+++ b/frontend/cstar_perf/frontend/server/model.py
@@ -385,11 +385,16 @@ class Model(object):
                 for jvm in row[2]:
                     jvms[jvm] =  row[2][jvm]
 
+            products = []
+            if row[4]:
+                for product in row[4]:
+                    products.append(product)
+
             clusters[row[0]] = {'name': row[0],
                                 'description': row[1],
                                 'jvms': jvms,
                                 'num_nodes' : row[3],
-                                'additional_products' : row[4]}
+                                'additional_products' : products}
         return clusters
 
     def add_cluster_jvm(self, cluster, version, path):

--- a/frontend/cstar_perf/frontend/server/model.py
+++ b/frontend/cstar_perf/frontend/server/model.py
@@ -91,9 +91,10 @@ class Model(object):
         'select_test_status_all': "SELECT * FROM test_status WHERE status = ? LIMIT ?",
         'delete_test_status': "DELETE FROM test_status WHERE status= ? AND cluster = ? AND test_id = ?",
         'select_clusters_name': "SELECT name from clusters;",
-        'select_clusters': "SELECT name, description, jvms, num_nodes FROM clusters;",
+        'select_clusters': "SELECT name, description, jvms, num_nodes, additional_products FROM clusters;",
         'insert_clusters': "INSERT INTO clusters (name, num_nodes, description) VALUES (?, ?, ?)",
         'add_cluster_jvm': "UPDATE clusters SET jvms[?]=? WHERE name = ?",
+        'add_cluster_product': "UPDATE clusters SET additional_products=additional_products + ? WHERE name = ?",
         'insert_user': "INSERT INTO users (user_id, full_name, roles) VALUES (?, ?, ?);",
         'select_user': "SELECT * FROM users WHERE user_id = ?;",
         'select_user_passphrase_hash': "SELECT hash, salt FROM user_passphrase WHERE user_id = ?;",
@@ -179,7 +180,7 @@ class Model(object):
         session.execute("CREATE TABLE test_artifacts (test_id timeuuid, artifact_type text, description text, artifact blob, PRIMARY KEY (test_id, artifact_type));")
 
         # Cluster information
-        session.execute("CREATE TABLE clusters (name text PRIMARY KEY, num_nodes int, description text, jvms map<text, text>)")
+        session.execute("CREATE TABLE clusters (name text PRIMARY KEY, num_nodes int, description text, jvms map<text, text>, additional_products set<text>)")
         
         #Users
         session.execute("CREATE TABLE users (user_id text PRIMARY KEY, full_name text, roles set <text>);")
@@ -387,12 +388,17 @@ class Model(object):
             clusters[row[0]] = {'name': row[0],
                                 'description': row[1],
                                 'jvms': jvms,
-                                'num_nodes' : row[3]}
+                                'num_nodes' : row[3],
+                                'additional_products' : row[4]}
         return clusters
 
     def add_cluster_jvm(self, cluster, version, path):
         session = self.get_session()
         session.execute(self.__prepared_statements['add_cluster_jvm'], (version, path, cluster))
+
+    def add_cluster_product(self, cluster, product):
+        session = self.get_session()
+        session.execute(self.__prepared_statements['add_cluster_product'], (product, cluster))
 
     ################################################################################
     #### API Keys:

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -8,10 +8,22 @@ var addRevisionDiv = function(animate){
     var revision_id = 'revision-'+schedule.n_revisions;
     var template = "<div id='{revision_id}' class='revision'><legend>Test Revisions<a id='remove-{revision_id}' class='pull-right remove-revision'><span class='glyphicon" +
         "                  glyphicon-remove'></span></a></legend>" +
+
+        "      <div class='form-group'>" +
+        "        <label class='col-md-4 control-label' for='{revision_id}-product'>Product</label>" +
+        "        <div class='col-md-8'>" +
+        "          <select id='{revision_id}-product' " +
+        "                  class='product-select form-control' required>" +
+        "            <option value='cassandra'>Cassandra</option>" +
+        "            <option value='dse'>DSE</option>" +
+        "          </select>" +
+        "        </div>" +
+        "      </div>" +
+
         "      <div class='form-group'>" +
         "        <label class='col-md-4 control-label' for='{revision_id}-refspec'>Revision</label>  " +
         "        <div class='col-md-8'>" +"" +
-        "          <input id='{revision_id}-refspec' type='text' placeholder='Git branch, tag, or commit id' class='refspec form-control input-md' required>" +
+        "          <input id='{revision_id}-refspec' type='text' placeholder='Git branch, tag, commit id or DSE version' class='refspec form-control input-md' required>" +
         "        </div>" +
         "      </div>" +
         "" +
@@ -64,7 +76,7 @@ var addRevisionDiv = function(animate){
         "      </div>" +
         "    </div>";
     var newDiv = $(template.format({revision:schedule.n_revisions, revision_id:revision_id}));
-    if (animate) 
+    if (animate)
         newDiv.hide();
     $("#schedule-revisions").append(newDiv);
     if (animate)
@@ -210,12 +222,13 @@ var createJob = function() {
         cluster: $("#cluster").val(),
         num_nodes: $("#numnodes").val(),
     }
-    
+
     //Revisions:
     job.revisions = [];
     $("#schedule-revisions div.revision").each(function(i, revision) {
         revision = $(revision);
         job.revisions[i] = {
+            product: revision.find(".product-select").val(),
             revision: revision.find(".refspec").val(),
             label: revision.find(".revision-label").val() ? revision.find(".revision-label").val() : null,
             yaml: revision.find(".yaml").val(),
@@ -256,7 +269,7 @@ var show_job_json = function() {
 var cloneExistingJob = function(job_id) {
     $.get("/api/tests/id/" + job_id, function(job) {
         test = job['test_definition'];
-        $("input#testname").val(test['title']); 
+        $("input#testname").val(test['title']);
         $("textarea#description").val(test['description']);
         $("select#cluster").val(test['cluster']);
         $("select#numnodes").val(test['num_nodes']);
@@ -265,6 +278,7 @@ var cloneExistingJob = function(job_id) {
             addRevisionDiv(false);
             var rev = i + 1;
             $("#revision-"+rev+"-refspec").val(revision['revision']);
+            $("#revision-"+rev+"-product").val(revision['product']);
             $("#revision-"+rev+"-label").val(revision['label']);
             $("#revision-"+rev+"-yaml").val(revision['yaml']);
             $("#revision-"+rev+"-env-vars").val(revision['env']);
@@ -317,7 +331,7 @@ var update_jvm_selections = function(callback) {
                 alert("Warning - cluster JVM selection changed")
             }
         });
-        if (callback != null) 
+        if (callback != null)
             callback();
     });
 }
@@ -356,7 +370,7 @@ $(document).ready(function() {
         addOperationDiv(false, 'stress', 'write n=19000000 -rate threads=50');
         addOperationDiv(false, 'stress', 'read n=19000000 -rate threads=50');
     }
-    
+
     //Validate form and submit:
     $("form#schedule-test").submit(function(e) {
         var job = createJob();

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -316,6 +316,11 @@ var update_cluster_options = function(callback) {
         } else {
             $(".product-select-div").show();
         }
+
+        if (callback) {
+            callback();
+        }
+
     });
 }
 

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -282,6 +282,7 @@ var cloneExistingJob = function(job_id) {
             $("#revision-"+rev+"-options-vnodes").prop("checked", revision['options']['use_vnodes'])
             update_cluster_options(function(){
                 $("#revision-"+rev+"-jvm").val(revision['java_home']);
+                $("#revision-"+rev+"-product").val(revision['product']);
             });
 
         });

--- a/frontend/cstar_perf/frontend/static/js/util.js
+++ b/frontend/cstar_perf/frontend/static/js/util.js
@@ -81,6 +81,7 @@ function update_select_with_values(element, values, context) {
             alert("Warning - cluster "+context+" selection changed from '"+current_selections[i]+"' to '"+$(e).val()+"'");
         }
     });
+
 }
 
 $(document).ready(function() {

--- a/frontend/cstar_perf/frontend/static/js/util.js
+++ b/frontend/cstar_perf/frontend/static/js/util.js
@@ -52,6 +52,36 @@ parseUri.options = {
 };
 
 
+function update_select_with_values(element, values, context) {
+    var el = $(element);
+
+    //Remember the current jvm selections:
+    var current_selections = [];
+    el.each(function(i, e) {
+        current_selections[i] = $(e).val();
+    });
+
+    //Clear out the lists and fetch new one:
+    el.empty();
+    if(values==null || values.length == 0) {
+        alert("Warning: cluster has no "+context+" defined.");
+    }
+
+    $.each(values, function(key, val) {
+        el.append($("<option value='"+val+"'>"+key+"</option>"));
+    });
+
+    //Try to set the one we had from before:
+    el.each(function(i, e) {
+        if (current_selections[i] != null) {
+            $(e).val(current_selections[i]);
+        }
+        if ($(e).val() == null) {
+            $(e).find("option:first-child").attr("selected", "selected");
+            alert("Warning - cluster "+context+" selection changed from '"+current_selections[i]+"' to '"+$(e).val()+"'");
+        }
+    });
+}
 
 $(document).ready(function() {
     setupCSRFAjax();

--- a/tool/cstar_perf/docker/cstar_docker.py
+++ b/tool/cstar_perf/docker/cstar_docker.py
@@ -525,12 +525,12 @@ def associate(frontend_name, cluster_names, with_dse=False):
     try:
         frontend = get_clusters(frontend_name, all_metadata=True)[frontend_name][0]
     except IndexError:
-        raise ValueError("No cluster named {} found".format(frontend_name))
+        raise ValueError("No frontend cluster named {} found".format(frontend_name))
 
     clusters = []
     for c in cluster_names:
         try:
-            cluster = get_clusters(c, all_metadata=True)[c]
+            cluster = get_clusters(c, all_metadata=True)[c][0]
         except IndexError:
             raise ValueError("No cluster named {} found".format(c))
         clusters.append(cluster)
@@ -543,7 +543,7 @@ def associate(frontend_name, cluster_names, with_dse=False):
 
     for cluster in clusters:
         num_nodes = len(cluster)-1
-        cluster = cluster[0]  # first node
+        cluster = cluster
         cluster_name = cluster['Config']['Labels']['cluster_name']
         cluster_ip = cluster['NetworkSettings']['IPAddress']
         with fab.settings(hosts=cluster_ip):
@@ -755,7 +755,7 @@ def main():
         '--destroy-existing', help='Destroy any existing cluster with the same name before launching', action="store_true")
 
     associate = parser_subparsers.add_parser('associate', description="Hook up one or more clusters to a cluster")
-    associate.add_argument('cluster', help='The name of the cluster')
+    associate.add_argument('frontend', help='The name of the frontend cluster')
     associate.add_argument('clusters', help='The names of the clusters to hook up to the frontend', nargs='+')
     associate.add_argument('--with-dse', help='Enable DSE product for this cluster', action='store_true', default=False)
 

--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -22,8 +22,9 @@ import yaml
 import sh
 import itertools
 
-# Import the default config first:
-import fab_cassandra as cstar
+# Import the default config first:r
+import fab_common as common
+import fab_dse as dse
 # Then import our cluster specific config:
 from cluster_config import config
 
@@ -37,11 +38,19 @@ sh.ErrorReturnCode.truncate_cap = 999999
 HOME = os.getenv('HOME')
 CASSANDRA_STRESS_PATH = os.path.expanduser("~/fab/stress/")
 CASSANDRA_STRESS_DEFAULT   = os.path.expanduser("~/fab/stress/default/tools/bin/cassandra-stress")
-CASSANDRA_NODETOOL = os.path.expanduser("~/fab/cassandra/bin/nodetool")
-CASSANDRA_CQLSH    = os.path.expanduser("~/fab/cassandra/bin/cqlsh")
 JAVA_HOME          = os.path.expanduser("~/fab/java")
 
 antcmd = sh.Command(os.path.join(HOME, 'fab/ant/bin/ant'))
+
+global nodetool_path, cqlsh_path
+
+def set_nodetool_path(path):
+    global nodetool_path
+    nodetool_path = path
+
+def set_cqlsh_path(path):
+    global cqlsh_path
+    cqlsh = path
 
 def bootstrap(cfg=None, destroy=False, leave_data=False, git_fetch=True):
     """Deploy and start cassandra on the cluster
@@ -54,7 +63,7 @@ def bootstrap(cfg=None, destroy=False, leave_data=False, git_fetch=True):
     Return the gid id of the branch checked out
     """
     if cfg is not None:
-        cstar.setup(cfg)
+        common.setup(cfg)
 
     # Parse yaml 
     if cfg.has_key('yaml'):
@@ -65,14 +74,14 @@ def bootstrap(cfg=None, destroy=False, leave_data=False, git_fetch=True):
             cass_yaml = {}
         if type(cass_yaml) is not dict:
             raise JobFailure('Invalid yaml, was expecting a dictionary: {cass_yaml}'.format(cass_yaml=cass_yaml))
-        cstar.config['yaml'] = cass_yaml
+        common.config['yaml'] = cass_yaml
     if cfg.has_key('options'):
         if cfg['options'] is not None:
-            cstar.config.update(cfg['options'])
-            del cstar.config['options']
+            common.config.update(cfg['options'])
+            del common.config['options']
 
     logger.info("### Config: ###")
-    pprint(cstar.config)
+    pprint(common.config)
 
     # leave_data settting can be set in the revision
     # configuration, or manually in the call to this function.
@@ -91,66 +100,80 @@ def bootstrap(cfg=None, destroy=False, leave_data=False, git_fetch=True):
 
     # Destroy cassandra deployment and data:
     if destroy:
-        execute(cstar.destroy, leave_data=leave_data)
-        execute(cstar.ensure_stopped)
+        execute(common.destroy, leave_data=leave_data)
+        execute(common.ensure_stopped)
     else:
         #Shutdown cleanly:
-        execute(cstar.stop)
-        execute(cstar.ensure_stopped)
+        execute(common.stop)
+        execute(common.ensure_stopped)
+
+    # dse setup and binaries download (local)
+    dse.setup(common.config)
+
+    product = dse if common.config['product'] == 'dse' else cstar
+    set_nodetool_path(os.path.join(product.get_bin_path(), 'nodetool'))
+    set_cqlsh_path(os.path.join(product.get_bin_path(), 'cqlsh'))
 
     # Bootstrap C* onto the cluster nodes, as well as the localhost,
     # so we have access to nodetool, stress etc - the local host will
     # not be added to the cluster unless it has a corresponding entry
     # in the cluster config:
-    hosts = list(cstar.fab.env['hosts'])
+    hosts = list(common.fab.env['hosts'])
     localhost = socket.gethostname().split(".")[0]
     if localhost not in [host.split(".")[0] for host in hosts]:
         # Use the local username for this host, as it may be different
         # than the cluster defined 'user' parameter:
         hosts += [getpass.getuser() + "@" + localhost]
     if not cfg.get('revision_override'):
-        with cstar.fab.settings(hosts=hosts):
-            git_ids = execute(cstar.bootstrap, git_fetch=git_fetch)
+        with common.fab.settings(hosts=hosts):
+            git_ids = execute(common.bootstrap, git_fetch=git_fetch)
     else:
+        # revision_override is only supported for the product cassandra
+        if product != 'cassandra':
+            raise ValueError("Cannot use revision_override for product: {}".format(
+                product.name))
         git_ids = {}
         default_hosts = set(hosts) - set(itertools.chain(*cfg['revision_override'].values()))
         print 'default version on {default_hosts}'.format(default_hosts=default_hosts)
-        with cstar.fab.settings(hosts=default_hosts):
-            git_ids.update(execute(cstar.bootstrap, git_fetch=git_fetch))
+        with common.fab.settings(hosts=default_hosts):
+            git_ids.update(execute(common.bootstrap, git_fetch=git_fetch))
         for override_revision, hosts_to_override in cfg['revision_override'].items():
 	    print '{revision} on {hosts_to_override}'.format(revision=override_revision, hosts_to_override=hosts_to_override)
-            with cstar.fab.settings(hosts=hosts_to_override):
-                git_ids.update(execute(cstar.bootstrap, git_fetch=git_fetch, revision_override=override_revision))
+            with common.fab.settings(hosts=hosts_to_override):
+                git_ids.update(execute(common.bootstrap, git_fetch=git_fetch, revision_override=override_revision))
 
-    overridden_host_versions = {}
-    for v, hs in cfg.get('revision_override', {}).items():
-        overridden_host_versions.update({h: v for h in hs})
-    expected_host_versions = dict({h: cfg['revision'] for h in hosts}, **overridden_host_versions)
-    expected_host_shas = {h: str(sh.git('--git-dir={home}/fab/cassandra.git'.format(home=HOME), 'rev-parse', v))
-                          for (h, v) in expected_host_versions.items()}
-    expected_host_shas = {h: v.strip() for (h, v) in expected_host_shas.items()}
+    if product.name == 'cassandra':
+        overridden_host_versions = {}
+        for v, hs in cfg.get('revision_override', {}).items():
+            overridden_host_versions.update({h: v for h in hs})
+        expected_host_versions = dict({h: cfg['revision'] for h in hosts}, **overridden_host_versions)
+        expected_host_shas = {h: str(sh.git('--git-dir={home}/fab/cassandra.git'.format(home=HOME), 'rev-parse', v))
+                              for (h, v) in expected_host_versions.items()}
+        expected_host_shas = {h: v.strip() for (h, v) in expected_host_shas.items()}
 
-    assert expected_host_shas == git_ids, 'expected: {}\ngot:{}'.format(expected_host_shas, git_ids)
+        assert expected_host_shas == git_ids, 'expected: {}\ngot:{}'.format(expected_host_shas, git_ids)
 
-    execute(cstar.start)
-    execute(cstar.ensure_running, hosts=[cstar.config['seeds'][0]])
+    execute(common.start)
+    execute(common.ensure_running, hosts=[common.config['seeds'][0]])
     time.sleep(30)
 
-    logger.info("Started cassandra on {n} nodes with git SHAs: {git_ids}".format(n=len(cstar.fab.env['hosts']), git_ids=git_ids))
+    logger.info("Started {product} on {n} nodes with git SHAs: {git_ids}".format(
+        product=product.name, n=len(common.fab.env['hosts']), git_ids=git_ids))
+    time.sleep(30)
     return git_ids
 
 def restart():
-    execute(cstar.stop)
-    execute(cstar.ensure_stopped)
-    execute(cstar.start)
-    execute(cstar.ensure_running)
+    execute(common.stop)
+    execute(common.ensure_stopped)
+    execute(common.start)
+    execute(common.ensure_running)
 
 def teardown(destroy=False, leave_data=False):
     if destroy:
-        execute(cstar.destroy, leave_data=leave_data)
+        execute(common.destroy, leave_data=leave_data)
     else:
-        execute(cstar.stop)
-        execute(cstar.ensure_stopped)
+        execute(common.stop)
+        execute(common.ensure_stopped)
 
 class NodetoolException(Exception):
     pass
@@ -160,8 +183,8 @@ def nodetool(cmd):
     
     Raises NodetoolException if we can't connect or another error occurs:
     """
-    cmd = "JAVA_HOME={JAVA_HOME} {CASSANDRA_NODETOOL} {cmd}".format(
-        JAVA_HOME=JAVA_HOME, CASSANDRA_NODETOOL=CASSANDRA_NODETOOL, cmd=cmd)
+    cmd = "JAVA_HOME={JAVA_HOME} {nodetool_path} {cmd}".format(
+        JAVA_HOME=JAVA_HOME, nodetool_path=nodetool_path, cmd=cmd)
     proc = subprocess.Popen(cmd, 
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT,
@@ -183,15 +206,16 @@ def bash(script, nodes=None, user=None):
     if type(script) in (list, tuple):
         script = "\n".join(script)
     if nodes is None:
-        nodes = cstar.fab.env.hosts
+        nodes = common.fab.env.hosts
     if user is None:
-        user = cstar.fab.env.user
-    with cstar.fab.settings(user=user, hosts=nodes):
-        execute(cstar.bash, script)
+        user = common.fab.env.user
+    with common.fab.settings(user=user, hosts=nodes):
+        execute(common.bash, script)
 
 def cqlsh(script, node):
     """Run a cqlsh script on a node"""
-    proc = subprocess.Popen(shlex.split(CASSANDRA_CQLSH + " --no-color {host}".format(host=node)), 
+    cmd = "{cqlsh_path} --no-color {host}".format(cqlsh_path=cqlsh_path, host=node)
+    proc = subprocess.Popen(shlex.split(cmd),
                             stdout=subprocess.PIPE,
                             stdin=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
@@ -295,7 +319,7 @@ def wait_for_compaction(nodes=None, check_interval=30, idle_confirmations=3,
                                 nodes=nodes, output=output))
 
     if nodes is None:
-        nodes = set(cstar.fab.env.hosts)
+        nodes = set(common.fab.env.hosts)
     else:
         nodes = set(nodes)
 
@@ -323,7 +347,7 @@ def set_device_read_ahead(read_ahead, devices=None):
     If devices argument is None, use the 'block_devices' setting from the cluster config."""
     if devices is None:
         devices = config['block_devices']
-    execute(cstar.set_device_read_ahead, read_ahead, devices)
+    execute(common.set_device_read_ahead, read_ahead, devices)
 
 def drop_page_cache():
     """Drop the page cache"""
@@ -432,19 +456,19 @@ def stress(cmd, revision_tag, stats=None, stress_revision=None):
 
 def retrieve_logs(local_directory):
     """Retrieve each node's logs to the given local directory."""
-    execute(cstar.copy_logs, local_directory=local_directory)
+    execute(common.copy_logs, local_directory=local_directory)
 
 def retrieve_fincore_logs(local_directory):
     """Retrieve each node's fincore logs to the given local directory."""
-    execute(cstar.copy_fincore_logs, local_directory=local_directory)
+    execute(common.copy_fincore_logs, local_directory=local_directory)
 
 def start_fincore_capture(interval=10):
     """Start linux-fincore monitoring of Cassandra data files on each node"""
-    execute(cstar.start_fincore_capture, interval=interval)
+    execute(common.start_fincore_capture, interval=interval)
 
 def stop_fincore_capture():
     """Stop linux-fincore monitoring"""
-    execute(cstar.stop_fincore_capture)
+    execute(common.stop_fincore_capture)
 
 def log_add_data(file, data):
     """Merge the dictionary data into the json log file root."""

--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -25,6 +25,8 @@ import itertools
 # Import the default config first:r
 import fab_common as common
 import fab_dse as dse
+import fab_cassandra as cstar
+
 # Then import our cluster specific config:
 from cluster_config import config
 

--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -109,10 +109,12 @@ def bootstrap(cfg=None, destroy=False, leave_data=False, git_fetch=True):
         execute(common.stop)
         execute(common.ensure_stopped)
 
-    # dse setup and binaries download (local)
-    dse.setup(common.config)
-
     product = dse if common.config['product'] == 'dse' else cstar
+
+    # dse setup and binaries download (local)
+    if product == dse:
+        dse.setup(common.config)
+
     set_nodetool_path(os.path.join(product.get_bin_path(), 'nodetool'))
     set_cqlsh_path(os.path.join(product.get_bin_path(), 'cqlsh'))
 

--- a/tool/cstar_perf/tool/bootstrap.py
+++ b/tool/cstar_perf/tool/bootstrap.py
@@ -1,5 +1,5 @@
-from benchmark import (bootstrap, stress, nodetool, teardown, 
-                       log_stats, log_set_title, retrieve_logs, cstar, config)
+from benchmark import (bootstrap, stress, nodetool, teardown,
+                       log_stats, log_set_title, retrieve_logs, config)
 from fabric.tasks import execute
 import argparse
 import sys

--- a/tool/cstar_perf/tool/fab_cassandra.py
+++ b/tool/cstar_perf/tool/fab_cassandra.py
@@ -1,36 +1,11 @@
-###############################################################################
-## Fabric file to bootstrap Apache Cassandra on a set of nodes
-## 
-## Examples:
-## 
-## Install and configure Cassandra, setup firewall, start seeds, start
-## nodes:
-##
-##  fab -f fab_dse.py configure_hostnames
-##  fab -f fab_dse.py configure_firewall
-##  fab -f fab_dse.py install_java
-##  fab -f fab_dse.py bootstrap
-##  fab -f fab_dse.py start:just_seeds=True
-##  fab -f fab_dse.py start
-## 
-##  OR, all in one:
-##
-##  fab -f fab_cassandra.py bootstrap_all
-################################################################################
-from StringIO import StringIO
-import time
-import fabric
-from fabric import api as fab
-import os
-import yaml
-from cluster_config import config as cluster_config
 import re
-import uuid
-from util import random_token
 import json
+import yaml
+from fabric import api as fab
 
-fab.env.use_ssh_config = True
-fab.env.connection_attempts = 10
+name = 'cassandra'
+
+MAX_CACHED_BUILDS = 10
 
 # Git repositories
 GIT_REPOS = [
@@ -58,178 +33,11 @@ GIT_REPOS = [
 # Additional git remotes can be specified in this file
 GIT_REMOTES_FILE = os.path.join(os.path.expanduser("~"), ".cstar_perf", "git_remotes.json")
 
-CMD_LINE_HOSTS_SPECIFIED = False
-if len(fab.env.hosts) > 0 :
-    CMD_LINE_HOSTS_SPECIFIED = True
+def get_cassandra_path():
+    return 'fab/cassandra'
 
-MAX_CACHED_BUILDS = 10
-
-logback_template = """<configuration scan="true">
-  <jmxConfigurator />
-  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <file>${cassandra.logdir}/system.log</file>
-    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-      <fileNamePattern>${cassandra.logdir}/system.log.%i.zip</fileNamePattern>
-      <minIndex>1</minIndex>
-      <maxIndex>20</maxIndex>
-    </rollingPolicy>
-
-    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-      <maxFileSize>20MB</maxFileSize>
-    </triggeringPolicy>
-    <encoder>
-      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
-      <!-- old-style log format
-      <pattern>%5level [%thread] %date{ISO8601} %F (line %L) %msg%n</pattern>
-      -->
-    </encoder>
-  </appender>
-  
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-    <encoder>
-      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
-    </encoder>
-  </appender>
-        
-  <root level="INFO">
-    <appender-ref ref="FILE" />
-    <appender-ref ref="STDOUT" />
-  </root>
-  
-  <logger name="com.thinkaurelius.thrift" level="ERROR"/>
-</configuration>
-"""
-
-log4j_template = """
-log4j.rootLogger=INFO,stdout,R
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p %d{HH:mm:ss,SSS} %m%n
-log4j.appender.R=org.apache.log4j.RollingFileAppender
-log4j.appender.R.maxFileSize=20MB
-log4j.appender.R.maxBackupIndex=50
-log4j.appender.R.layout=org.apache.log4j.PatternLayout
-log4j.appender.R.layout.ConversionPattern=%5p [%t] %d{ISO8601} %F (line %L) %m%n
-log4j.appender.R.File=${cassandra.logdir}/system.log
-log4j.logger.org.apache.thrift.server.TNonblockingServer=ERROR
-"""
-
-# An error will be raised if a user try to modify these c* config.
-# They can only be set in the cluster config.
-DENIED_CSTAR_CONFIG = ['commitlog_directory', 'data_file_directories', 'saved_caches_directory']
-
-################################################################################
-### Setup Configuration:
-################################################################################
-def setup(my_config=None):
-    global config
-
-    def __get_balanced_tokens(node_count, partitioner='murmur3'):
-        if partitioner == 'murmur3':
-            return [str(((2**64 / node_count) * i) - 2**63) 
-                    for i in range(node_count)]
-        elif partitioner == 'random':
-            return [str(i*(2**127/node_count)) for i in range(0, node_count)]
-        else:
-            raise ValueError('Unknonwn partitioner: %s' % partitioner)
-
-    ########################################
-    ### Default config:
-    ########################################
-    default_config = {
-        # The git revision id or tag to use:
-        'revision': 'trunk',
-        # Override version, tell ant to build with a given version name:
-        'override_version': None,
-        # Cluster name
-        'cluster_name': 'cstar_perf {random_string}'.format(random_string=random_token()),
-        # Ant tarball:
-        'ant_tarball' : 'http://www.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.tar.bz2',
-        # The user to install as
-        'user': 'ryan',
-        'partitioner': 'murmur3', #murmur3 or random
-        'git_repo': 'git://github.com/apache/cassandra.git',
-        # Enable vnodes:
-        'use_vnodes': True,
-        # Number of vnodes per node. Ignored if use_vnodes == False:
-        'num_tokens': 256,
-        # Directories:
-        'data_file_directories': ['/var/lib/cassandra/data'],
-        'commitlog_directory': '/var/lib/cassandra/commitlog',
-        'saved_caches_directory': '/var/lib/cassandra/saved_caches',
-        'flush_directory': '/var/lib/cassandra/flush',
-        # Log file:
-        'log_dir': '~/fab/cassandra/logs',
-        # Device readahead setting. None means use system default.
-        'blockdev_readahead': None,
-        # Block devices that above readahead setting affects:
-        'block_devices': [],
-        # Force loading JNA on <2.0 (2.1+ has it by default):
-        'use_jna': True,
-        # Extra environment settings to prepend to cassandra-env.sh:
-        'env': '',
-        'java_home': '~/fab/java'
-    }
-
-    public_ips = "node0, node1, node2, node3"
-    private_ips = "192.168.1.141,192.168.1.145,192.168.1.143,192.168.1.133"
-    public_ips = public_ips.replace(" ","").split(",")
-    private_ips = private_ips.replace(" ","").split(",")
-
-    tokens = __get_balanced_tokens(len(public_ips), default_config['partitioner'])    
-    default_config.setdefault('hosts', {})
-    first_node = True
-    for i, public, private, token in zip(
-            xrange(len(public_ips)), public_ips, private_ips, tokens):
-        if not default_config['hosts'].has_key(public):
-            default_config['hosts'][public] = {
-                #Local hostname to give the host: 
-                'hostname': 'node%s' % i,
-                #Internal IP address of the host:
-                'internal_ip': private,
-                }
-            if not default_config['use_vnodes']:
-                default_config['hosts'][public]['initial_token'] = token
-            # Make the first node a seed:
-            if first_node:
-                default_config['hosts'][public]['seed'] = True
-                first_node = False
-
-    ########################################
-    ### End default config
-    ########################################
-
-    # Use default values where not specified:
-    if not my_config:
-        config = default_config
-    else:
-        config = dict(default_config.items() + my_config.items())
-
-    # Retokenize if needed:
-    for node in config['hosts'].values():
-        if not config['use_vnodes'] and not node.has_key('initial_token'):
-            # At least one node was missing it's token, retokenize all the nodes:
-            tokens = __get_balanced_tokens(len(config['hosts']), config['partitioner'])
-            for node,token in zip(config['hosts'].values(), tokens):
-                node['initial_token'] = token
-            break
-
-    #Aggregate those nodes which are seeds into a single list:
-    config['seeds'] = [v.get('external_ip', v['internal_ip']) for v in config['hosts'].values() 
-                      if v.get('seed',False)]
-
-    # Tell fabric which hosts to use, unless some were 
-    # specified on the command line:
-    if not CMD_LINE_HOSTS_SPECIFIED:
-        fab.env.hosts = [h for h in config['hosts']]
-    fab.env.user = config['user']
-
-## Setup default configuration:
-# First call without arguments sets up default config:
-setup()
-# Second call with cluster_config argument sets up further defaults
-# for the configured cluster:
-setup(cluster_config)
+def get_bin_path():
+    return 'fab/cassandra/bin'
 
 def get_git_repos():
     """Returns all static git repos and additional repos"""
@@ -245,7 +53,7 @@ def get_git_repos():
 
     return repos
 
-def get_cassandra_config_options():
+def get_cassandra_config_options(config):
     """Parse Cassandra's Config class to get all possible config values. 
 
     Unfortunately, some are hidden from the default cassandra.yaml file, so this appears the only way to do this."""
@@ -265,17 +73,13 @@ def get_cassandra_config_options():
     opts = yaml.load(out)
     p = re.compile("^[a-z][^A-Z]*$")
     return [o for o in opts if p.match(o)]
-    
-@fab.parallel
-def bootstrap(git_fetch=True, revision_override=None):
-    """Install and configure Cassandra on each host
-    
-    Returns the git id for the version checked out.
-    """
-    revision = revision_override or config['revision']
-    partitioner = config['partitioner']
 
-    fab.run('mkdir -p fab')
+def bootstrap(config, git_fetch=True):
+    """Install and configure Cassandra
+    Returns the git id or the version checked out.
+    """
+
+    revision = config['revision']
 
     #Fetch latest git changes:
     if git_fetch:
@@ -304,7 +108,7 @@ def bootstrap(git_fetch=True, revision_override=None):
 
             fab.run('git --git-dir=$HOME/fab/cassandra.git fetch {name}'.format(name=name))
             # TODO: What did this used to do? This used to be necessary,
-            # but now it appears to delete branches: 
+            # but now it appears to delete branches:
             # fab.run('git --git-dir=$HOME/fab/cassandra.git fetch -fup {name} +refs/*:refs/*'
             #         .format(name=name))
 
@@ -325,7 +129,7 @@ def bootstrap(git_fetch=True, revision_override=None):
         fab.run('mkdir ~/fab/cassandra')
         fab.run('git --git-dir=$HOME/fab/cassandra.git archive %s |'
                 ' tar x -C ~/fab/cassandra' % revision)
-        fab.run('echo -e \'%s\\n%s\\n%s\' > ~/fab/cassandra/0.GIT_REVISION.txt' % 
+        fab.run('echo -e \'%s\\n%s\\n%s\' > ~/fab/cassandra/0.GIT_REVISION.txt' %
                 (revision, git_id, config.get('log','')))
 
         fab.run('JAVA_HOME={java_home} ~/fab/ant/bin/ant -f ~/fab/cassandra/build.xml clean'.format(java_home=config['java_home']))
@@ -343,381 +147,25 @@ def bootstrap(git_fetch=True, revision_override=None):
             fab.run('ls -t1 ~/fab/cassandra_builds | tail -n {num_to_delete} | xargs -iXX rm -rf ~/fab/cassandra_builds/XX'.format(
                 num_to_delete=num_builds-MAX_CACHED_BUILDS))
 
-    # Get host config:
-    try:
-        cfg = config['hosts'][fab.env.host]
-    except KeyError:
-        # If host has no config, don't configure it. This is used for
-        # compiling the source on the controlling node which is
-        # usually not a part of the cluster.
-        return git_id
-
-    #Ensure JNA is available:
-    if config['use_jna']:
-        # Check if JNA already exists:
-        jna_exists = fab.run('ls ~/fab/cassandra/lib/jna*.jar', quiet=True)
-        if jna_exists.return_code != 0:
-            # Symlink system JNA to cassandra lib dir:
-            jna_candidates = ['/usr/share/java/jna/jna.jar', '/usr/share/java/jna.jar']
-            for jar in jna_candidates:
-                if fab.run('ls {jar}'.format(jar=jar), quiet=True).return_code == 0:
-                    fab.run('ln -s {jar} ~/fab/cassandra/lib/jna.jar'.format(jar=jar))
-                    break
-            else:
-                raise AssertionError('Could not force JNA loading, no JNA jar found.')
-    else:
-        fab.run('rm -f ~/fab/cassandra/lib/jna*')
-
-    # Configure cassandra.yaml:
-    conf_file = StringIO()
-    fab.get('~/fab/cassandra/conf/cassandra.yaml', conf_file)
-    conf_file.seek(0)
-    cass_yaml = yaml.load(conf_file.read())
-
-    # Get the canonical list of options from the c* source code:
-    cstar_config_opts = get_cassandra_config_options()
-
-    # Cassandra YAML values can come from two places: 
-    # 1) Set as options at the top level of the config. This is how
-    # legacy cstar_perf did it. These are unvalidated:
-    for option, value in config.items():
-        if option in cstar_config_opts:
-            cass_yaml[option] = value
-    # 2) Set in the second level 'yaml' dictionary. This is how the
-    # frontend and bootstrap.py does it. These take precedence over
-    # the #1 style and are always validated for typos / invalid options.
-    for option, value in config.get('yaml', {}).items():
-        if option in DENIED_CSTAR_CONFIG:
-            raise ValueError(
-                'C* yaml option "{}" can only be set in the cluster config.'.format(option)
-            )
-        elif option not in cstar_config_opts:
-            raise ValueError('Unknown C* yaml option: {}'.format(option))
-        cass_yaml[option] = value
-
-    if 'num_tokens' not in config.get('yaml', {}):
-        if config.get('use_vnodes', True):
-            cass_yaml['num_tokens'] = config['num_tokens']
-        else:
-            cass_yaml['initial_token'] = cfg['initial_token']
-            cass_yaml['num_tokens'] = 1
-    cass_yaml['listen_address'] = cfg['internal_ip']
-    cass_yaml['broadcast_address'] = cfg.get('external_ip', cfg['internal_ip'])
-    cass_yaml['seed_provider'][0]['parameters'][0]['seeds'] =  ",".join(config['seeds'])
-    if partitioner == 'random':
-        cass_yaml['partitioner'] = 'org.apache.cassandra.dht.RandomPartitioner'
-    elif partitioner == 'murmur3':
-        cass_yaml['partitioner'] = 'org.apache.cassandra.dht.Murmur3Partitioner'
-    cass_yaml['rpc_address'] = cfg['internal_ip']
-
-    #Configure Topology:
-    if not config.has_key('endpoint_snitch'):
-        for node in config['hosts'].values():
-            if node.get('datacenter',False):
-                config['endpoint_snitch'] = "GossipingPropertyFileSnitch"
-                cass_yaml['auto_bootstrap'] = False
-                break
-        else:
-            config['endpoint_snitch'] = "SimpleSnitch"
-
-    if config['endpoint_snitch'] == 'PropertyFileSnitch':
-        cass_yaml['endpoint_snitch'] = 'PropertyFileSnitch'
-        fab.run("echo 'default=dc1:r1' > fab/cassandra/conf/cassandra-topology.properties")
-        for node in config['hosts'].values():
-            line = '%s=%s:%s' % (node['external_ip'], node.get('datacenter', 'dc1'), node.get('rack', 'r1'))
-            fab.run("echo '%s' >> fab/cassandra/conf/cassandra-topology.properties" % line)
-    if config['endpoint_snitch'] == "GossipingPropertyFileSnitch":
-        cass_yaml['endpoint_snitch'] = 'GossipingPropertyFileSnitch'
-        fab.run("echo 'dc={dc}\nrack={rack}' > fab/cassandra/conf/cassandra-rackdc.properties".format(
-            dc=cfg.get('datacenter','dc1'), rack=cfg.get('rack','r1')))
-
-    # Save config:
-    conf_file = StringIO()
-    conf_file.write(yaml.safe_dump(cass_yaml, encoding='utf-8', allow_unicode=True))
-    conf_file.seek(0)
-    fab.put(conf_file, '~/fab/cassandra/conf/cassandra.yaml')
-
-    # Configure logback:
-    logback_conf = StringIO()
-    # Get absolute path to log dir:
-    log_dir = fab.run("readlink -m {log_dir}".format(log_dir=config['log_dir']))
-    logback_conf.write(logback_template.replace("${cassandra.logdir}",log_dir))
-    logback_conf.seek(0)
-    fab.put(logback_conf, '~/fab/cassandra/conf/logback.xml')
-
-    # Configure log4j:
-    log4j_conf = StringIO()
-    log4j_conf.write(log4j_template.replace("${cassandra.logdir}",log_dir))
-    log4j_conf.seek(0)
-    fab.put(log4j_conf, '~/fab/cassandra/conf/log4j-server.properties')
-
-    # Copy fincore utility:
-    fincore_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),'fincore_capture.py')
-    fab.put(fincore_script, '~/fab/fincore_capture.py')
     return git_id
 
 @fab.parallel
-def destroy(leave_data=False):
-    """Uninstall Cassandra and clean up data and logs"""
-    # We used to have a better pattern match for the Cassandra
-    # process, but it got fragile if you put too many JVM params. 
-    fab.run('killall -9 java', quiet=True)
-    fab.run('pkill -f "python.*fincore_capture"', quiet=True)
-    fab.run('rm -rf fab/cassandra')
-    fab.run('rm -rf fab/scripts')
-    fab.run('rm -f fab/nohup.log')
+def add_git_remotes():
+    for name,url in git_repos:
+        fab.run('git --git-dir=$HOME/fab/cassandra.git remote add {name} {url}'
+                .format(name=name, url=url), quiet=True)
 
-    # Ensure directory configurations look sane
-    assert type(config['data_file_directories']) == list
-    for t in [config['saved_caches_directory'], config['commitlog_directory'],
-              config['flush_directory'], config['log_dir']] + config['data_file_directories']:
-        assert type(t) in (str, unicode) and len(t) > 1, '{t} doesn\'t look like a directory'.format(t=t)
-    
-    if not leave_data:
-        for d in config['data_file_directories']:
-            fab.run('rm -rf {data}/*'.format(data=d))
-        fab.run('rm -rf {saved_caches_directory}/*'.format(saved_caches_directory=config['saved_caches_directory']))
-        fab.run('rm -rf {commitlog}/*'.format(commitlog=config['commitlog_directory']))
-        fab.run('rm -rf {flushdir}/*'.format(flushdir=config['flush_directory']))
-    fab.run('rm -rf {log_dir}'.format(log_dir=config['log_dir']))
-    fab.run('rm -f /tmp/fincore.stats.log')
-
-@fab.parallel
-def start():
-    """Start casssandra nodes"""
-    # Get host config:
-    cfg = config['hosts'][fab.env.host]
-
-    # Place environment file on host:
-    env = config.get('env', '')
-    fab.puts('env is: {}'.format(env))
-
-    if isinstance(env, list) or isinstance(env, tuple):
-        env = "\n".join(env)
-    env += "\n"
-    fab.puts('env is: {}'.format(env))
-    if not config['use_jna']:
-        env = 'JVM_EXTRA_OPTS=-Dcassandra.boot_without_jna=true\n\n' + env
-    # Turn on GC logging:
-    fab.run("mkdir -p ~/fab/cassandra/logs")
-    log_dir = fab.run("readlink -m {log_dir}".format(log_dir=config['log_dir']))
-    env = "JVM_OPTS=\"$JVM_OPTS -Djava.rmi.server.hostname={hostname} -Xloggc:{log_dir}/gc.log\"\n\n".format(
-        hostname=fab.env.host, log_dir=log_dir) + env
-    # Enable JMX without authentication
-    env = "JVM_OPTS=\"$JVM_OPTS -Dcom.sun.management.jmxremote.port=7199 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\"\n" + env
-    
-    env_script = "{name}.sh".format(name=uuid.uuid1())
-    env_file = StringIO(env)
-    fab.run('mkdir -p ~/fab/scripts')
-    fab.put(env_file, '~/fab/scripts/{env_script}'.format(env_script=env_script))
-
-    fab.puts('env is: {}'.format(env))
-    if len(env_script) > 0:
-        fab.run('echo >> ~/fab/scripts/{env_script}'.format(**locals()))
-        fab.run('cat ~/fab/cassandra/conf/cassandra-env.sh >> ~/fab/scripts/{env_script}'.format(**locals()))
-        fab.run('cp ~/fab/scripts/{env_script} ~/fab/cassandra/conf/cassandra-env.sh'.format(**locals()))
-
+def start(config):
     fab.puts("Starting Cassandra..")
     cmd = 'JAVA_HOME={java_home} nohup ~/fab/cassandra/bin/cassandra'.format(java_home=config['java_home'])
     fab.run(cmd)
 
-@fab.parallel
-def stop(clean=True):
+def stop(clean):
     if clean:
         fab.run('pkill -f "java.*org.apache.*.CassandraDaemon"', quiet=True)
     else:
         fab.run('pkill -9 -f "java.*org.apache.*.CassandraDaemon"', quiet=True)
 
-def ensure_running(retries=15, wait=10):
-    """Ensure cassandra is running on all nodes.
-    Runs 'nodetool ring' on a single node continuously until it 
-    reaches the specified number of retries.
-    
-    INTENDED TO BE RUN ON ONE NODE, NOT ALL.
-    """
-    time.sleep(15)
-    for attempt in range(retries):
-        ring = StringIO(fab.run('JAVA_HOME={java_home} ~/fab/cassandra/bin/nodetool ring'.format(java_home=config['java_home'])))
-        broadcast_ips = [x.get('external_ip', x['internal_ip']) for x in config['hosts'].values()]
-        nodes_up = dict((host,False) for host in broadcast_ips)
-        for line in ring:
-            for host in broadcast_ips:
-                if host in line and " Up " in line:
-                    nodes_up[host] = True
-        for node,up in nodes_up.items():
-            if not up:
-                fab.puts("Node is not up (yet): %s" % node)
-        if False not in nodes_up.values():
-            fab.puts("All nodes available!")
-            return
-        fab.puts("waiting %d seconds to try again.." % wait)
-        time.sleep(wait)
-    else:
-        fab.abort("Timed out waiting for all nodes to startup")
-
-@fab.parallel
-def ensure_stopped(retries=15, wait=10):
-    """Ensure cassandra is stopped on all nodes.
-    Checks continuously until it reaches the specified number of retries."""
-    for attempt in range(retries):
-        pgrep = fab.run('pgrep -f "java.*org.apache.*.CassandraDaemon"', quiet=True)
-        if pgrep.return_code != 0:
-            fab.puts('Cassandra shutdown.')
-            return
-        fab.puts("waiting %d seconds to try again.." % wait)
-        time.sleep(wait)
-    else:
-        fab.abort("Timed out waiting for all nodes to stop")
-
-@fab.parallel
-def install_java(packages=None):
-    # Try to get the os distribution:
-    dist = fab.run('lsb_release -is', quiet=True)
-    if dist.return_code != 0:
-        dist = fab.run('cat /etc/redhat-release', quiet=True)
-    if dist.startswith('CentOS'):
-        if not packages:
-            packages = ['java-1.7.0-openjdk.x86_64', 
-                        'java-1.7.0-openjdk-devel.x86_64']
-        cmd = 'yum -y install {package}'
-    elif dist.startswith('Ubuntu'):
-        if not packages:
-            packages = ['openjdk-7-jdk']
-        fab.run('apt-get update')
-        cmd = 'apt-get -y install {package}'
-    else:
-        raise RuntimeError('Unknown distribution: %s' % dist)
-    for package in packages:
-        fab.run(cmd.format(package=package))
-        
-@fab.parallel
-def configure_hostnames():
-    # Get host config:
-    cfg = config['hosts'][fab.env.host]
-    fab.run('hostname {0}'.format(cfg['hostname']))
-    fab.run('echo "127.0.0.1       localhost.localdomain   localhost"'
-            ' > /etc/hosts')
-    fab.run('echo "::1       localhost.localdomain   localhost" >> /etc/hosts')
-    for cfg in config['hosts'].values():
-        fab.run('echo "{ip}     {hostname}" >> /etc/hosts'.format(
-                ip=cfg['internal_ip'], hostname=cfg['hostname']))
-
-@fab.parallel
-def copy_logs(local_directory):
-    cfg = config['hosts'][fab.env.host]
-    host_log_dir = os.path.join(local_directory, cfg['hostname'])
-    os.mkdir(host_log_dir)
-    fab.get(os.path.join(config['log_dir'],'*'), host_log_dir)
-
-@fab.parallel
-def start_fincore_capture(interval=10):
-    """Start fincore_capture utility on each node"""
-    fab.puts("Starting fincore_capture daemon...")
-    fab.run('python2.7 fab/fincore_capture.py -i {interval}'.format(interval=interval))
-
-@fab.parallel
-def stop_fincore_capture():
-    """Stop fincore_capture utility on each node"""
-    fab.puts("Stopping fincore_capture.")
-    fab.run('pkill -f ".*python.*fincore_capture"', quiet=True)
-
-@fab.parallel
-def copy_fincore_logs(local_directory):
-    cfg = config['hosts'][fab.env.host]
-    location = os.path.join(local_directory, "fincore.{host}.log".format(host=cfg['hostname']))
-    fab.get('/tmp/fincore.stats.log', location)
-
-@fab.parallel
-def whoami():
-    fab.run('whoami')
-
-@fab.parallel
-def add_git_remotes():
-    repos = get_git_repos()
-    for name, url in repos:
-        fab.run('git --git-dir=$HOME/fab/cassandra.git remote add {name} {url}'
-                .format(name=name, url=url), quiet=True)
-
-@fab.parallel
-def copy_root_setup():
-    fab.run('ln -s ~/fab/apache-ant-1.9.2 ~/fab/ant')
-
-@fab.parallel
-def set_device_read_ahead(read_ahead, devices):
-    with fab.settings(user='root'):
-        for device in devices:
-            if 'docker' in device:
-                continue # Docker has no device handle, so we can't set any parameters on it
-            fab.run('blockdev --setra {read_ahead} {device}'.format(read_ahead=read_ahead,device=device))
-
-@fab.parallel
-def build_jbod_drives(device_mounts, md_device='/dev/md/striped', filesystem='ext4'):
-    """Build a jbod configuration for drives
-    
-    device_mounts - a dictionary of device names -> mountpoints. Alternatively, can be a string representation.
-        fab -f fab_cassandra.py build_jbod_drives:"{'/dev/sdb1':'/mnt/d1'\,'/dev/sdc1':'/mnt/d2'\,'/dev/sdd1':'/mnt/d3'\,'/dev/sde1':'/mnt/d4'\,'/dev/sdf1':'/mnt/d5'\,'/dev/sdg1':'/mnt/d6'\,'/dev/sdh1':'/mnt/d7'}"
-    md_device - The mdadm striped device that may need to be destoyed first.
-
-    Formats the devices and mounts the filesystems.
-    """
-    with fab.settings(user='root'):
-        if isinstance(device_mounts, basestring):
-            device_mounts = eval(device_mounts)
-
-        # Destroy the mdadm striped device:
-        fab.run('umount {md_device} && mdadm --stop {md_device}'.format(**locals()), quiet=True)
-
-        mounted = fab.run('mount',quiet=True)
-        for device in [d for d in device_mounts.keys() if d in mounted]:
-            # Unmount devices:
-            fab.run('umount -f {device}'.format(**locals()))
-
-        # Format in parallel :
-        fab.run('echo -e "{devices}" | xargs -n 1 -P {num} -iXX mkfs -t {filesystem} XX'.format(devices="\n".join(device_mounts.keys()), filesystem=filesystem, num=len(device_mounts)))
-
-        for device,mountpoint in device_mounts.items():
-            # Mount:
-            fab.run('mount {device} {mountpoint}'.format(**locals()))
-            fab.run('chmod 777 {mountpoint}'.format(**locals()))
-
-@fab.parallel
-def build_striped_drives(devices, mount_point='/mnt/striped', filesystem='ext4', chunk_size=64, md_device='/dev/md/striped'):
-    """Build a striped array of drives with mdadm
-
-    devices - a list of device names to include in the array 
-            - altenatively, a string delimitted with semicolons for use on the command line:
-
-        fab -f fab_cassandra.py build_striped_drives:'/dev/sdb1;/dev/sdc1;/dev/sdd1;/dev/sde1;/dev/sdf1;/dev/sdg1;/dev/sdh1',/mnt/striped
-    """
-    with fab.settings(user='root'):
-        if isinstance(devices, basestring):
-            devices = devices.split(";")
-
-        # Unmount devices:
-        mounted = fab.run('mount',quiet=True)
-        for device in [d for d in devices + [mount_point] if d in mounted]:
-            fab.run('umount -f {device}'.format(**locals()))
-
-        # Stop any existing array:
-        fab.run('mdadm --stop {md_device}'.format(**locals()),quiet=True)
-        
-        # Create new array:
-        fab.run('mdadm --create {md_device} -R --verbose --level=0 --metadata=1.2 --chunk={chunk_size} --raid-devices={num} {devices}'.format(
-            md_device=md_device, num=len(devices), chunk_size=chunk_size, devices=" ".join(devices)))
-
-        # Format it:
-        fab.run('mkfs -t {filesystem} {md_device}'.format(**locals()))
-
-        # Mount it:
-        fab.run('mkdir -p {mount_point} && mount {md_device} {mount_point}'.format(**locals()))
-
-        fab.run('chmod 777 {mount_point}'.format(**locals()))
-
-@fab.parallel
-def bash(script):
-    """Run a bash script on the host"""
-    script = StringIO(script)
-    fab.run('mkdir -p ~/fab/scripts')
-    script_path = '~/fab/scripts/{script_name}.sh'.format(script_name=uuid.uuid1())
-    fab.put(script, script_path)
-    fab.run('bash {script_path}'.format(script_path=script_path))
+def is_running():
+    pgrep = fab.run('pgrep -f "java.*org.apache.*.CassandraDaemon"', quiet=True)
+    return True if pgrep.return_code == 0 else False

--- a/tool/cstar_perf/tool/fab_cassandra.py
+++ b/tool/cstar_perf/tool/fab_cassandra.py
@@ -1,3 +1,4 @@
+import os
 import re
 import json
 import yaml
@@ -34,10 +35,10 @@ GIT_REPOS = [
 GIT_REMOTES_FILE = os.path.join(os.path.expanduser("~"), ".cstar_perf", "git_remotes.json")
 
 def get_cassandra_path():
-    return 'fab/cassandra'
+    return os.path.expanduser('~/fab/cassandra')
 
 def get_bin_path():
-    return 'fab/cassandra/bin'
+    return os.path.expanduser('~/fab/cassandra/bin')
 
 def get_git_repos():
     """Returns all static git repos and additional repos"""

--- a/tool/cstar_perf/tool/fab_cassandra.py
+++ b/tool/cstar_perf/tool/fab_cassandra.py
@@ -152,7 +152,7 @@ def bootstrap(config, git_fetch=True):
 
 @fab.parallel
 def add_git_remotes():
-    for name,url in git_repos:
+    for name,url in get_git_repos():
         fab.run('git --git-dir=$HOME/fab/cassandra.git remote add {name} {url}'
                 .format(name=name, url=url), quiet=True)
 

--- a/tool/cstar_perf/tool/fab_common.py
+++ b/tool/cstar_perf/tool/fab_common.py
@@ -1,0 +1,640 @@
+###############################################################################
+## Fabric file to bootstrap Apache Cassandra on a set of nodes
+##
+## Examples:
+##
+## Install and configure Cassandra, setup firewall, start seeds, start
+## nodes:
+##
+##  fab -f fab_dse.py configure_hostnames
+##  fab -f fab_dse.py configure_firewall
+##  fab -f fab_dse.py install_java
+##  fab -f fab_dse.py bootstrap
+##  fab -f fab_dse.py start:just_seeds=True
+##  fab -f fab_dse.py start
+##
+##  OR, all in one:
+##
+##  fab -f fab_cassandra.py bootstrap_all
+################################################################################
+from StringIO import StringIO
+import time
+from fabric import api as fab
+import os
+import yaml
+from cluster_config import config as cluster_config
+import re
+import uuid
+from util import random_token
+import fab_dse as dse
+import fab_cassandra as cstar
+
+fab.env.use_ssh_config = True
+fab.env.connection_attempts = 10
+
+# Git repositories
+git_repos = [
+    ('apache',        'git://github.com/apache/cassandra.git'),
+    ('enigmacurry',   'git://github.com/EnigmaCurry/cassandra.git'),
+    ('knifewine',     'git://github.com/knifewine/cassandra.git'),
+    ('shawnkumar',    'git://github.com/shawnkumar/cassandra.git'),
+    ('mambocab',      'git://github.com/mambocab/cassandra.git'),
+    ('jbellis',       'git://github.com/jbellis/cassandra.git'),
+    ('marcuse',       'git://github.com/krummas/cassandra.git'),
+    ('pcmanus',       'git://github.com/pcmanus/cassandra.git'),
+    ('belliottsmith', 'git://github.com/belliottsmith/cassandra.git'),
+    ('bes',           'git://github.com/belliottsmith/cassandra.git'),
+    ('iamaleksey',    'git://github.com/iamaleksey/cassandra.git'),
+    ('tjake',         'git://github.com/tjake/cassandra.git'),
+    ('carlyeks',      'git://github.com/carlyeks/cassandra.git'),
+    ('aweisberg',     'git://github.com/aweisberg/cassandra.git'),
+    ('mstump',        'git://github.com/mstump/cassandra.git'),
+    ('snazy',         'git://github.com/snazy/cassandra.git'),
+    ('blambov',       'git://github.com/blambov/cassandra.git'),
+    ('stef1927',      'git://github.com/stef1927/cassandra.git'),
+    ('driftx',      'git://github.com/driftx/cassandra.git')
+]
+
+CMD_LINE_HOSTS_SPECIFIED = False
+if len(fab.env.hosts) > 0 :
+    CMD_LINE_HOSTS_SPECIFIED = True
+
+logback_template = """<configuration scan="true">
+  <jmxConfigurator />
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${cassandra.logdir}/system.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <fileNamePattern>${cassandra.logdir}/system.log.%i.zip</fileNamePattern>
+      <minIndex>1</minIndex>
+      <maxIndex>20</maxIndex>
+    </rollingPolicy>
+
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>20MB</maxFileSize>
+    </triggeringPolicy>
+    <encoder>
+      <pattern>%-5level [%thread] %date{ISO8601} %F:%L - %msg%n</pattern>
+      <!-- old-style log format
+      <pattern>%5level [%thread] %date{ISO8601} %F (line %L) %msg%n</pattern>
+      -->
+    </encoder>
+  </appender>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%-5level %date{HH:mm:ss,SSS} %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="FILE" />
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <logger name="com.thinkaurelius.thrift" level="ERROR"/>
+</configuration>
+"""
+
+log4j_template = """
+log4j.rootLogger=INFO,stdout,R
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p %d{HH:mm:ss,SSS} %m%n
+log4j.appender.R=org.apache.log4j.RollingFileAppender
+log4j.appender.R.maxFileSize=20MB
+log4j.appender.R.maxBackupIndex=50
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=%5p [%t] %d{ISO8601} %F (line %L) %m%n
+log4j.appender.R.File=${cassandra.logdir}/system.log
+log4j.logger.org.apache.thrift.server.TNonblockingServer=ERROR
+"""
+
+# An error will be raised if a user try to modify these c* config.
+# They can only be set in the cluster config.
+DENIED_CSTAR_CONFIG = ['commitlog_directory', 'data_file_directories', 'saved_caches_directory']
+
+################################################################################
+### Setup Configuration:
+################################################################################
+def setup(my_config=None):
+    global config
+
+    def __get_balanced_tokens(node_count, partitioner='murmur3'):
+        if partitioner == 'murmur3':
+            return [str(((2**64 / node_count) * i) - 2**63)
+                    for i in range(node_count)]
+        elif partitioner == 'random':
+            return [str(i*(2**127/node_count)) for i in range(0, node_count)]
+        else:
+            raise ValueError('Unknonwn partitioner: %s' % partitioner)
+
+    ########################################
+    ### Default config:
+    ########################################
+    default_config = {
+        # Product to test: cassandra or dse
+        'product': 'cassandra',
+        # The git revision id or tag to use:
+        'revision': 'trunk',
+        # Override version, tell ant to build with a given version name:
+        'override_version': None,
+        # Cluster name
+        'cluster_name': 'cstar_perf {random_string}'.format(random_string=random_token()),
+        # Ant tarball:
+        'ant_tarball' : 'http://www.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.tar.bz2',
+        # The user to install as
+        'user': 'ryan',
+        'partitioner': 'murmur3', #murmur3 or random
+        'git_repo': 'git://github.com/apache/cassandra.git',
+        # Enable vnodes:
+        'use_vnodes': True,
+        # Number of vnodes per node. Ignored if use_vnodes == False:
+        'num_tokens': 256,
+        # Directories:
+        'data_file_directories': ['/var/lib/cassandra/data'],
+        'commitlog_directory': '/var/lib/cassandra/commitlog',
+        'saved_caches_directory': '/var/lib/cassandra/saved_caches',
+        'flush_directory': '/var/lib/cassandra/flush',
+        # Log file:
+        'log_dir': '~/fab/cassandra/logs',
+        # Device readahead setting. None means use system default.
+        'blockdev_readahead': None,
+        # Block devices that above readahead setting affects:
+        'block_devices': [],
+        # Force loading JNA on <2.0 (2.1+ has it by default):
+        'use_jna': True,
+        # Extra environment settings to prepend to cassandra-env.sh:
+        'env': '',
+        'java_home': '~/fab/java'
+    }
+
+    public_ips = "node0, node1, node2, node3"
+    private_ips = "192.168.1.141,192.168.1.145,192.168.1.143,192.168.1.133"
+    public_ips = public_ips.replace(" ","").split(",")
+    private_ips = private_ips.replace(" ","").split(",")
+
+    tokens = __get_balanced_tokens(len(public_ips), default_config['partitioner'])
+    default_config.setdefault('hosts', {})
+    first_node = True
+    for i, public, private, token in zip(
+            xrange(len(public_ips)), public_ips, private_ips, tokens):
+        if not default_config['hosts'].has_key(public):
+            default_config['hosts'][public] = {
+                #Local hostname to give the host:
+                'hostname': 'node%s' % i,
+                #Internal IP address of the host:
+                'internal_ip': private,
+                }
+            if not default_config['use_vnodes']:
+                default_config['hosts'][public]['initial_token'] = token
+            # Make the first node a seed:
+            if first_node:
+                default_config['hosts'][public]['seed'] = True
+                first_node = False
+
+    ########################################
+    ### End default config
+    ########################################
+
+    # Use default values where not specified:
+    if not my_config:
+        config = default_config
+    else:
+        config = dict(default_config.items() + my_config.items())
+
+    # Retokenize if needed:
+    for node in config['hosts'].values():
+        if not config['use_vnodes'] and not node.has_key('initial_token'):
+            # At least one node was missing it's token, retokenize all the nodes:
+            tokens = __get_balanced_tokens(len(config['hosts']), config['partitioner'])
+            for node,token in zip(config['hosts'].values(), tokens):
+                node['initial_token'] = token
+            break
+
+    #Aggregate those nodes which are seeds into a single list:
+    config['seeds'] = [v.get('external_ip', v['internal_ip']) for v in config['hosts'].values()
+                      if v.get('seed',False)]
+
+    # Tell fabric which hosts to use, unless some were
+    # specified on the command line:
+    if not CMD_LINE_HOSTS_SPECIFIED:
+        fab.env.hosts = [h for h in config['hosts']]
+    fab.env.user = config['user']
+
+## Setup default configuration:
+# First call without arguments sets up default config:
+setup()
+# Second call with cluster_config argument sets up further defaults
+# for the configured cluster:
+setup(cluster_config)
+
+@fab.parallel
+def bootstrap(git_fetch=True, revision_override=None):
+    """Install and configure the specified product on each host
+
+    Returns the git id for the version checked out.
+    """
+    revision = revision_override or config['revision']
+    partitioner = config['partitioner']
+
+    fab.run('mkdir -p fab')
+
+    if config['product'] not in ('cassandra', 'dse'):
+        raise ValueError("Invalid product. Should be cassandra or dse")
+
+    product = dse if config['product'] == 'dse' else cstar
+
+    if product.name == 'dse':
+        rev_id = dse.bootstrap(config)
+    else:
+        rev_id = cstar.bootstrap(config, git_fetch)
+
+    cassandra_path = product.get_cassandra_path()
+
+    # Get host config:
+    try:
+        cfg = config['hosts'][fab.env.host]
+    except KeyError:
+        # If host has no config, don't configure it. This is used for
+        # compiling the source on the controlling node which is
+        # usually not a part of the cluster.
+        return rev_id
+
+    #Ensure JNA is available:
+    if config['use_jna']:
+        # Check if JNA already exists:
+        jna_jars = os.path.join(cassandra_path, 'lib/jna*.jar')
+        jna_jar = os.path.join(cassandra_path, 'lib/jna.jar')
+        jna_exists = fab.run('ls {}'.format(jna_jars), quiet=True)
+        if jna_exists.return_code != 0:
+            # Symlink system JNA to cassandra lib dir:
+            jna_candidates = ['/usr/share/java/jna/jna.jar', '/usr/share/java/jna.jar']
+            for jar in jna_candidates:
+                if fab.run('ls {jar}'.format(jar=jar), quiet=True).return_code == 0:
+                    fab.run('ln -s {jar} {jna}'.format(jar=jar, jna=jna_jar))
+                    break
+            else:
+                if not os.path.exists('fab/jna.jar'):
+                    request = download_file(JNA_LIB_URL, 'fab/jna.jar')
+                    if request.status_code != requests.codes.ok:
+                        raise AssertionError('Could not force JNA loading, no JNA jar found.')
+
+                fab.put('fab/jna.jar', jna_jar)
+    else:
+        fab.run('rm -f {}'.format(os.path.join(cassandra_path, 'lib/jna*')))
+
+    # Configure cassandra.yaml:
+    conf_file = StringIO()
+    fab.get(os.path.join(cassandra_path, 'conf/cassandra.yaml'), conf_file)
+    conf_file.seek(0)
+    cass_yaml = yaml.load(conf_file.read())
+
+    # Get the canonical list of options from the c* source code:
+    if product.name == 'dse':
+        cstar_config_opts = cass_yaml.keys()
+    else:
+        cstar_config_opts = product.get_cassandra_config_options(config)
+
+    # Cassandra YAML values can come from two places:
+    # 1) Set as options at the top level of the config. This is how
+    # legacy cstar_perf did it. These are unvalidated:
+    for option, value in config.items():
+        if option in cstar_config_opts:
+            cass_yaml[option] = value
+    # 2) Set in the second level 'yaml' dictionary. This is how the
+    # frontend and bootstrap.py does it. These take precedence over
+    # the #1 style and are always validated for typos / invalid options.
+    for option, value in config.get('yaml', {}).items():
+        if option in DENIED_CSTAR_CONFIG:
+            raise ValueError(
+                'C* yaml option "{}" can only be set in the cluster config.'.format(option)
+            )
+        elif option not in cstar_config_opts:
+            raise ValueError('Unknown C* yaml option: {}'.format(option))
+        cass_yaml[option] = value
+
+    if 'num_tokens' not in config.get('yaml', {}):
+        if config.get('use_vnodes', True):
+            cass_yaml['num_tokens'] = config['num_tokens']
+        else:
+            cass_yaml['initial_token'] = cfg['initial_token']
+            cass_yaml['num_tokens'] = 1
+    cass_yaml['listen_address'] = cfg['internal_ip']
+    cass_yaml['broadcast_address'] = cfg.get('external_ip', cfg['internal_ip'])
+    cass_yaml['seed_provider'][0]['parameters'][0]['seeds'] =  ",".join(config['seeds'])
+    if partitioner == 'random':
+        cass_yaml['partitioner'] = 'org.apache.cassandra.dht.RandomPartitioner'
+    elif partitioner == 'murmur3':
+        cass_yaml['partitioner'] = 'org.apache.cassandra.dht.Murmur3Partitioner'
+    cass_yaml['rpc_address'] = cfg['internal_ip']
+
+    #Configure Topology:
+    if not config.has_key('endpoint_snitch'):
+        for node in config['hosts'].values():
+            if node.get('datacenter',False):
+                config['endpoint_snitch'] = "GossipingPropertyFileSnitch"
+                cass_yaml['auto_bootstrap'] = False
+                break
+        else:
+            config['endpoint_snitch'] = "SimpleSnitch"
+
+    conf_dir = os.path.join(cassandra_path, 'conf/')
+    if config['endpoint_snitch'] == 'PropertyFileSnitch':
+        cass_yaml['endpoint_snitch'] = 'PropertyFileSnitch'
+        fab.run("echo 'default=dc1:r1' > {}".format(conf_dir+'cassandra-topology.properties'))
+        for node in config['hosts'].values():
+            line = '%s=%s:%s' % (node['external_ip'], node.get('datacenter', 'dc1'), node.get('rack', 'r1'))
+            fab.run("echo '{}' >> {}".format(line, conf_dir+'cassandra-topology.properties'))
+    if config['endpoint_snitch'] == "GossipingPropertyFileSnitch":
+        cass_yaml['endpoint_snitch'] = 'GossipingPropertyFileSnitch'
+        fab.run("echo 'dc={dc}\nrack={rack}' > {out}".format(
+            dc=cfg.get('datacenter','dc1'), rack=cfg.get('rack','r1'),
+            out=conf_dir+'cassandra-rackdc.properties'))
+
+    # Save config:
+    conf_file = StringIO()
+    conf_file.write(yaml.safe_dump(cass_yaml, encoding='utf-8', allow_unicode=True))
+    conf_file.seek(0)
+    fab.put(conf_file, conf_dir+'cassandra.yaml')
+
+    # Configure logback:
+    logback_conf = StringIO()
+    # Get absolute path to log dir:
+    log_dir = fab.run("readlink -m {log_dir}".format(log_dir=config['log_dir']))
+    logback_conf.write(logback_template.replace("${cassandra.logdir}",log_dir))
+    logback_conf.seek(0)
+    fab.put(logback_conf, conf_dir+'logback.xml')
+
+    # Configure log4j:
+    log4j_conf = StringIO()
+    log4j_conf.write(log4j_template.replace("${cassandra.logdir}",log_dir))
+    log4j_conf.seek(0)
+    fab.put(log4j_conf, conf_dir+'log4j-server.properties')
+
+    # Copy fincore utility:
+    fincore_script = os.path.join(os.path.dirname(os.path.realpath(__file__)),'fincore_capture.py')
+    fab.put(fincore_script, '~/fab/fincore_capture.py')
+    return rev_id
+
+@fab.parallel
+def destroy(leave_data=False):
+    """Uninstall Cassandra and clean up data and logs"""
+    # We used to have a better pattern match for the Cassandra
+    # process, but it got fragile if you put too many JVM params.
+    fab.run('killall -9 java', quiet=True)
+    fab.run('pkill -f "python.*fincore_capture"', quiet=True)
+    fab.run('rm -rf fab/cassandra')
+    fab.run('rm -rf fab/dse')
+    fab.run('rm -rf fab/scripts')
+    fab.run('rm -f fab/nohup.log')
+
+    # Ensure directory configurations look sane
+    assert type(config['data_file_directories']) == list
+    for t in [config['saved_caches_directory'], config['commitlog_directory'],
+              config['flush_directory'], config['log_dir']] + config['data_file_directories']:
+        assert type(t) in (str, unicode) and len(t) > 1, '{t} doesn\'t look like a directory'.format(t=t)
+
+    if not leave_data:
+        for d in config['data_file_directories']:
+            fab.run('rm -rf {data}/*'.format(data=d))
+        fab.run('rm -rf {saved_caches_directory}/*'.format(saved_caches_directory=config['saved_caches_directory']))
+        fab.run('rm -rf {commitlog}/*'.format(commitlog=config['commitlog_directory']))
+        fab.run('rm -rf {flushdir}/*'.format(flushdir=config['flush_directory']))
+    fab.run('rm -rf {log_dir}'.format(log_dir=config['log_dir']))
+    fab.run('rm -f /tmp/fincore.stats.log')
+
+@fab.parallel
+def start():
+    """Start casssandra nodes"""
+
+    product = dse if config['product'] == 'dse' else cstar
+    cassandra_path = product.get_cassandra_path()
+
+    # Place environment file on host:
+    env = config.get('env', '')
+    fab.puts('env is: {}'.format(env))
+
+    if isinstance(env, list) or isinstance(env, tuple):
+        env = "\n".join(env)
+    env += "\n"
+    fab.puts('env is: {}'.format(env))
+    if not config['use_jna']:
+        env = 'JVM_EXTRA_OPTS=-Dcassandra.boot_without_jna=true\n\n' + env
+    # Turn on GC logging:
+    fab.run("mkdir -p ~/fab/cassandra/logs")
+    log_dir = fab.run("readlink -m {log_dir}".format(log_dir=config['log_dir']))
+    env = "JVM_OPTS=\"$JVM_OPTS -Djava.rmi.server.hostname={hostname} -Xloggc:{log_dir}/gc.log\"\n\n".format(
+        hostname=fab.env.host, log_dir=log_dir) + env
+    # Enable JMX without authentication
+    env = "JVM_OPTS=\"$JVM_OPTS -Dcom.sun.management.jmxremote.port=7199 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\"\n" + env
+
+    env_script = "{name}.sh".format(name=uuid.uuid1())
+    env_file = StringIO(env)
+    fab.run('mkdir -p ~/fab/scripts')
+    fab.put(env_file, '~/fab/scripts/{env_script}'.format(env_script=env_script))
+
+    fab.puts('env is: {}'.format(env))
+    if len(env_script) > 0:
+        env_path = os.path.join(cassandra_path, 'conf/cassandra-env.sh')
+        fab.run('echo >> ~/fab/scripts/{env_script}'.format(**locals()))
+        fab.run('cat {env_path} >> ~/fab/scripts/{env_script}'.format(**locals()))
+        fab.run('cp ~/fab/scripts/{env_script} {env_path}'.format(**locals()))
+
+    product.start(config)
+
+@fab.parallel
+def stop(clean=True):
+    product = dse if config['product'] == 'dse' else cstar
+    product.stop(clean)
+
+def ensure_running(retries=15, wait=10):
+    """Ensure cassandra is running on all nodes.
+    Runs 'nodetool ring' on a single node continuously until it
+    reaches the specified number of retries.
+
+    INTENDED TO BE RUN ON ONE NODE, NOT ALL.
+    """
+    product = dse if config['product'] == 'dse' else cstar
+    bin_path = product.get_bin_path()
+    nodetool_bin = os.path.join(bin_path, 'nodetool')
+    time.sleep(15)
+    for attempt in range(retries):
+        ring = StringIO(fab.run('JAVA_HOME={java_home} {nodetool_bin} ring'.format(
+            java_home=config['java_home'], nodetool_bin=nodetool_bin)))
+        broadcast_ips = [x.get('external_ip', x['internal_ip']) for x in config['hosts'].values()]
+        nodes_up = dict((host,False) for host in broadcast_ips)
+        for line in ring:
+            for host in broadcast_ips:
+                if host in line and " Up " in line:
+                    nodes_up[host] = True
+        for node,up in nodes_up.items():
+            if not up:
+                fab.puts("Node is not up (yet): %s" % node)
+        if False not in nodes_up.values():
+            fab.puts("All nodes available!")
+            return
+        fab.puts("waiting %d seconds to try again.." % wait)
+        time.sleep(wait)
+    else:
+        fab.abort("Timed out waiting for all nodes to startup")
+
+@fab.parallel
+def ensure_stopped(retries=15, wait=10):
+    """Ensure cassandra is stopped on all nodes.
+    Checks continuously until it reaches the specified number of retries."""
+    product = dse if config['product'] == 'dse' else cstar
+    for attempt in range(retries):
+        pgrep = fab.run('pgrep -f "java.*org.apache.*.CassandraDaemon"', quiet=True)
+        if not product.is_running():
+            fab.puts('Cassandra shutdown.')
+            return
+        fab.puts("waiting %d seconds to try again.." % wait)
+        time.sleep(wait)
+    else:
+        fab.abort("Timed out waiting for all nodes to stop")
+
+@fab.parallel
+def install_java(packages=None):
+    # Try to get the os distribution:
+    dist = fab.run('lsb_release -is', quiet=True)
+    if dist.return_code != 0:
+        dist = fab.run('cat /etc/redhat-release', quiet=True)
+    if dist.startswith('CentOS'):
+        if not packages:
+            packages = ['java-1.7.0-openjdk.x86_64',
+                        'java-1.7.0-openjdk-devel.x86_64']
+        cmd = 'yum -y install {package}'
+    elif dist.startswith('Ubuntu'):
+        if not packages:
+            packages = ['openjdk-7-jdk']
+        fab.run('apt-get update')
+        cmd = 'apt-get -y install {package}'
+    else:
+        raise RuntimeError('Unknown distribution: %s' % dist)
+    for package in packages:
+        fab.run(cmd.format(package=package))
+
+@fab.parallel
+def configure_hostnames():
+    # Get host config:
+    cfg = config['hosts'][fab.env.host]
+    fab.run('hostname {0}'.format(cfg['hostname']))
+    fab.run('echo "127.0.0.1       localhost.localdomain   localhost"'
+            ' > /etc/hosts')
+    fab.run('echo "::1       localhost.localdomain   localhost" >> /etc/hosts')
+    for cfg in config['hosts'].values():
+        fab.run('echo "{ip}     {hostname}" >> /etc/hosts'.format(
+                ip=cfg['internal_ip'], hostname=cfg['hostname']))
+
+@fab.parallel
+def copy_logs(local_directory):
+    cfg = config['hosts'][fab.env.host]
+    host_log_dir = os.path.join(local_directory, cfg['hostname'])
+    os.mkdir(host_log_dir)
+    fab.get(os.path.join(config['log_dir'],'*'), host_log_dir)
+
+@fab.parallel
+def start_fincore_capture(interval=10):
+    """Start fincore_capture utility on each node"""
+    fab.puts("Starting fincore_capture daemon...")
+    fab.run('python2.7 fab/fincore_capture.py -i {interval}'.format(interval=interval))
+
+@fab.parallel
+def stop_fincore_capture():
+    """Stop fincore_capture utility on each node"""
+    fab.puts("Stopping fincore_capture.")
+    fab.run('pkill -f ".*python.*fincore_capture"', quiet=True)
+
+@fab.parallel
+def copy_fincore_logs(local_directory):
+    cfg = config['hosts'][fab.env.host]
+    location = os.path.join(local_directory, "fincore.{host}.log".format(host=cfg['hostname']))
+    fab.get('/tmp/fincore.stats.log', location)
+
+@fab.parallel
+def whoami():
+    fab.run('whoami')
+
+@fab.parallel
+def copy_root_setup():
+    fab.run('ln -s ~/fab/apache-ant-1.9.2 ~/fab/ant')
+
+@fab.parallel
+def set_device_read_ahead(read_ahead, devices):
+    with fab.settings(user='root'):
+        for device in devices:
+            if 'docker' in device:
+                continue # Docker has no device handle, so we can't set any parameters on it
+            fab.run('blockdev --setra {read_ahead} {device}'.format(read_ahead=read_ahead,device=device))
+
+@fab.parallel
+def build_jbod_drives(device_mounts, md_device='/dev/md/striped', filesystem='ext4'):
+    """Build a jbod configuration for drives
+
+    device_mounts - a dictionary of device names -> mountpoints. Alternatively, can be a string representation.
+        fab -f fab_cassandra.py build_jbod_drives:"{'/dev/sdb1':'/mnt/d1'\,'/dev/sdc1':'/mnt/d2'\,'/dev/sdd1':'/mnt/d3'\,'/dev/sde1':'/mnt/d4'\,'/dev/sdf1':'/mnt/d5'\,'/dev/sdg1':'/mnt/d6'\,'/dev/sdh1':'/mnt/d7'}"
+    md_device - The mdadm striped device that may need to be destoyed first.
+
+    Formats the devices and mounts the filesystems.
+    """
+    with fab.settings(user='root'):
+        if isinstance(device_mounts, basestring):
+            device_mounts = eval(device_mounts)
+
+        # Destroy the mdadm striped device:
+        fab.run('umount {md_device} && mdadm --stop {md_device}'.format(**locals()), quiet=True)
+
+        mounted = fab.run('mount',quiet=True)
+        for device in [d for d in device_mounts.keys() if d in mounted]:
+            # Unmount devices:
+            fab.run('umount -f {device}'.format(**locals()))
+
+        # Format in parallel :
+        fab.run('echo -e "{devices}" | xargs -n 1 -P {num} -iXX mkfs -t {filesystem} XX'.format(devices="\n".join(device_mounts.keys()), filesystem=filesystem, num=len(device_mounts)))
+
+        for device,mountpoint in device_mounts.items():
+            # Mount:
+            fab.run('mount {device} {mountpoint}'.format(**locals()))
+            fab.run('chmod 777 {mountpoint}'.format(**locals()))
+
+@fab.parallel
+def build_striped_drives(devices, mount_point='/mnt/striped', filesystem='ext4', chunk_size=64, md_device='/dev/md/striped'):
+    """Build a striped array of drives with mdadm
+
+    devices - a list of device names to include in the array
+            - altenatively, a string delimitted with semicolons for use on the command line:
+
+        fab -f fab_cassandra.py build_striped_drives:'/dev/sdb1;/dev/sdc1;/dev/sdd1;/dev/sde1;/dev/sdf1;/dev/sdg1;/dev/sdh1',/mnt/striped
+    """
+    with fab.settings(user='root'):
+        if isinstance(devices, basestring):
+            devices = devices.split(";")
+
+        # Unmount devices:
+        mounted = fab.run('mount',quiet=True)
+        for device in [d for d in devices + [mount_point] if d in mounted]:
+            fab.run('umount -f {device}'.format(**locals()))
+
+        # Stop any existing array:
+        fab.run('mdadm --stop {md_device}'.format(**locals()),quiet=True)
+
+        # Create new array:
+        fab.run('mdadm --create {md_device} -R --verbose --level=0 --metadata=1.2 --chunk={chunk_size} --raid-devices={num} {devices}'.format(
+            md_device=md_device, num=len(devices), chunk_size=chunk_size, devices=" ".join(devices)))
+
+        # Format it:
+        fab.run('mkfs -t {filesystem} {md_device}'.format(**locals()))
+
+        # Mount it:
+        fab.run('mkdir -p {mount_point} && mount {md_device} {mount_point}'.format(**locals()))
+
+        fab.run('chmod 777 {mount_point}'.format(**locals()))
+
+@fab.parallel
+def bash(script):
+    """Run a bash script on the host"""
+    script = StringIO(script)
+    fab.run('mkdir -p ~/fab/scripts')
+    script_path = '~/fab/scripts/{script_name}.sh'.format(script_name=uuid.uuid1())
+    fab.put(script, script_path)
+    fab.run('bash {script_path}'.format(script_path=script_path))

--- a/tool/cstar_perf/tool/fab_deploy.py
+++ b/tool/cstar_perf/tool/fab_deploy.py
@@ -197,3 +197,37 @@ def get_client_jvms():
     output = fab.run("ls ~/fab/jvms")
     jvms = [jvm for jvm in output.split(' ') if jvm]
     return jvms
+
+def enable_dse(dse_repo_url, dse_repo_username=None, dse_repo_password=None):
+    """Enable DSE"""
+
+    enable_dse_script = """
+    import json
+    from cstar_perf.tool.cluster_config import cluster_config_file, config
+    config['dse_url'] = '{url}'
+    username = '{username}'
+    pw = '{pw}'
+    if username:
+        config['dse_username'] = username
+    elif 'dse_username' in config:
+        del config['dse_username']
+
+    if pw:
+        config['dse_password'] = pw
+    elif 'dse_password' in config:
+        del config['dse_password']
+
+    with open(cluster_config_file, 'w') as f:
+        f.write(json.dumps(config, sort_keys=True, indent=4, separators=(',', ': ')))
+    """.format(url=dse_repo_url, username=dse_repo_username, pw=dse_repo_password)
+    print run_python_script(enable_dse_script)
+
+def add_product_to_cluster(cluster_name, product):
+    """Add a product to a cluster configuration"""
+
+    add_cluster_product = """
+    from cstar_perf.frontend.server.model import Model
+    db = Model()
+    db.add_cluster_product('{name}', '{product}')
+    """.format(name=cluster_name, product=product)
+    run_python_script(add_cluster_product)

--- a/tool/cstar_perf/tool/fab_dse.py
+++ b/tool/cstar_perf/tool/fab_dse.py
@@ -1,0 +1,96 @@
+import os
+import requests
+from urlparse import urljoin
+from fabric import api as fab
+from util import download_file, download_file_contents, digest_file
+
+# I don't like global ...
+global config
+global dse_builds, dse_cache, dse_tarball
+
+name = 'dse'
+
+def setup(cfg):
+    "Local setup for dse"
+
+    global config, dse_builds, dse_cache, dse_tarball
+
+    config = cfg
+
+    if 'dse_url' not in  config:
+        raise ValueError("dse_url is missing from cluster_config.json.")
+
+    dse_tarball = "dse-{}-bin.tar.gz".format(config['revision'])
+
+    # Create dse_cache_dir
+    dse_builds = os.path.expanduser("~/fab/dse_builds")
+    dse_cache = os.path.join(dse_builds, '_cache')
+    if not os.path.exists(dse_cache):
+        os.makedirs(dse_cache)
+
+    if config["product"] == 'dse':
+        download_binaries()
+
+def download_binaries():
+    "Parse config and download dse binaries (local)"
+
+    # TODO since this is done locally on the cperf tool server, is there any possible concurrency
+    # issue .. Or maybe we should simply keep a cache on each host? (Comment to remove)
+    filename = os.path.join(dse_cache, dse_tarball)
+    if os.path.exists(filename):
+        print("Already in cache: {}".format(filename))
+        return
+
+    dse_url = config['dse_url']
+    username = config['dse_username'] if 'dse_username' in config else None
+    password = config['dse_password'] if 'dse_password' in config else None
+    url = urljoin(dse_url, dse_tarball)
+
+    # Fetch the SHA of the tarball:
+    correct_sha = download_file_contents(url+'.sha', username, password).split(" ")[0]
+    assert(len(correct_sha) == 64, 'Failed to download sha file: {}'.format(correct_sha))
+    # Fetch the tarball:
+    request = download_file(url, filename, username, password)
+    real_sha = digest_file(filename)
+    # Verify the SHA of the tarball:
+    if real_sha != correct_sha:
+        raise AssertionError('SHA of DSE tarball was not verified. should have been: {correct_sha} but saw {real_sha}'.format(
+            correct_sha=correct_sha, real_sha=real_sha))
+
+def get_dse_path():
+    return "~/fab/dse"
+
+def get_cassandra_path():
+    return os.path.join(get_dse_path(), 'resources/cassandra/')
+
+def get_bin_path():
+    return os.path.join(get_dse_path(), 'bin')
+
+def bootstrap(config):
+    filename = os.path.join(dse_cache, dse_tarball)
+    dest = os.path.join(dse_builds, dse_tarball)
+
+    # Upload the binaries
+    fab.run('mkdir -p {dse_builds}'.format(dse_builds=dse_builds))
+    fab.put(filename, dest)
+
+    # Extract the binaries
+    fab.run('tar -C {dse_builds} -xf {dest}'.format(dse_builds=dse_builds, dest=dest))
+
+    # Symlink current build to ~/fab/dse
+    fab.run('ln -sf {} ~/fab/dse'.format(os.path.join(dse_builds, dse_tarball.replace('-bin.tar.gz', ''))))
+
+    return config['revision']
+
+def start(config):
+    fab.puts("Starting DSE Cassandra..")
+    cmd = 'JAVA_HOME={java_home} nohup ~/fab/dse/bin/dse cassandra'.format(
+        java_home=config['java_home'])
+    fab.run(cmd)
+
+def stop(clean):
+    fab.run('jps | grep DseDaemon | cut -d" " -f1 | xargs kill -9', quiet=True)
+
+def is_running():
+    jps = fab.run('jps | grep DseDaemon"', quiet=True)
+    return True if jps.return_code == 0 else False

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -1,5 +1,5 @@
-from benchmark import (bootstrap, stress, nodetool, nodetool_multi, cqlsh, bash, teardown, 
-                       log_stats, log_set_title, log_add_data, retrieve_logs, cstar, restart,
+from benchmark import (bootstrap, stress, nodetool, nodetool_multi, cqlsh, bash, teardown,
+                       log_stats, log_set_title, log_add_data, retrieve_logs, restart,
                        start_fincore_capture, stop_fincore_capture, retrieve_fincore_logs,
                        drop_page_cache, wait_for_compaction, CASSANDRA_STRESS_PATH)
 from benchmark import config as fab_config

--- a/tool/cstar_perf/tool/util.py
+++ b/tool/cstar_perf/tool/util.py
@@ -1,6 +1,43 @@
 import string
 import random
+import requests
+import hashlib
 
 def random_token(length=10):
     return ''.join(random.choice(string.ascii_uppercase + string.digits)
                    for x in xrange(length))
+
+def download_file(url, dest, username=None, password=None):
+    "Download a file to disk"
+    print("Downloading {} --> {}".format(url, dest))
+    auth = (username, password) if username and password else None
+    request = requests.get(url, auth=auth, stream=True)
+    if request.status_code == requests.codes.ok:
+        CHUNK = 16 * 1024
+        with open(dest, 'wb') as fd:
+            for chunk in request.iter_content(CHUNK):
+                fd.write(chunk)
+    else:
+        request.raise_for_status()
+    return request
+
+def download_file_contents(url, username=None, password=None):
+    "Download a file, return it's contents"
+    print("Downloading {} ...".format(url))
+    auth = (username, password) if username and password else None
+    request = requests.get(url, auth=auth)
+    if request.status_code == requests.codes.ok:
+        return request.text
+    else:
+        request.raise_for_status()
+
+
+def digest_file(path, blocksize=2**20, hash_method='sha1'):
+    m = getattr(hashlib, hash_method)()
+    with open(path,'rb') as f:
+        while True:
+            buf = f.read(blocksize)
+            if not buf:
+                break
+            m.update(buf)
+    return m.hexdigest()

--- a/tool/setup.py
+++ b/tool/setup.py
@@ -5,7 +5,8 @@ requires = (
     'fabric',
     'pyyaml',
     'sh',
-    'fexpect'
+    'fexpect',
+    'requests'
 )
 
 setup(


### PR DESCRIPTION
This is an extension @aboudreault's DSE changes from #45 pulled into the cstar_perf repo along with some of my own changes.

Alan's original notes:

Add the DSE support to cstar_perf_tool.  Currently supported:

* Download the DSE binaries from the url config (dse-REVISION-bin.tar.gz)
* Cache DSE binaries on the *cstar_perf_tool server* (download only once, since DSE is ~500mb) 
* Setup DSE binaries in ~/fab
* Start Cassandra using bin/dse utility (DseDamon)
* Ensure things are started and running
* Product selection in the frontend (Cassandra or DSE)
* cstar_perf_stress should then work as normal

Misc Additions
* fab_common.py is now the main fabric tasks file. Based on the choosed product, it calls the proper functions from fab_cassandra.py or fab_dse.py
* JNA can now be downloaded from the web: (https://github.com/apache/cassandra/raw/trunk/lib/jna-4.0.0.jar)

### Cluster Configuration

This is what you need in cluster configuration:

```json
    "dse_url": "http://my-dse-repo/tar/",
    "dse_username": "XXXX",
    "dse_password": "YYYY"
```

### Possible Improvements
* Set DSE product optional, currently an error will be raised during benchmark setup
* ~~Check md5sum of the dse file before skipping the download~~
* Refactor the fab_common, fab_cassandra, fab_dse file. ie. it would be cleaner to have a kind of Configurator class and having 2 subclasses: CassandraConfigurator and DseConfigurator.

### Test files

#### cstar_perf_tool

```json
{
 "product": "dse",
 "ant_tarball": "http://www.apache.org/dist/ant/binaries/apache-ant-1.8.4-bin.tar.bz2",
 "block_devices":["/dev/sda"],
 "blockdev_readahead":"256",
 "cluster_name":"cstar_perf 7EEN4LQJFE",
 "commitlog_directory":"/home/vagrant/fab/node_data/commitlog",
 "data_file_directories":["/home/vagrant/fab/node_data/data"],
 "env":"",
 "flush_directory":"/home/vagrant/fab/node_data/flush",
 "git_repo":"git://github.com/apache/cassandra.git",
 "java_home":"~/fab/java",
 "log_dir":"~/fab/cassandra/logs",
 "num_tokens":256,
 "override_version":null,
 "partitioner":"murmur3",
 "revision":"4.6.2",
 "saved_caches_directory":"/home/vagrant/fab/node_data/saved_caches",
 "use_jna":true,
 "use_vnodes":true,
 "user":"vagrant"
}
```

#### cstar_perf_stress

```json
{
 "revisions":[
    {"product": "dse", "revision":"4.6.2"},
    {"product": "dse", "revision":"4.6.2", "memtable_allocation_type":"offheap_objects"}
 ],
 "title":"Test DSE offheap memtables",
 "log":"stats.dse-4.6.2.offheap_memtables.json",
 "operations": [
    {"type":"stress","command":"write n=65 -rate threads=40 -mode cql3 native"},
    {"type":"stress","command":"read n=65 -rate threads=40 -mode cql3 native"},
    {"type":"stress","command":"read n=65 -rate threads=40 -mode cql3 native"}]
}
```

Using cstar_docker, you can enable DSE on a cluster using:
```
cstar_docker enable_dse test_cluster "https://my.dse.repo.com/" <username> <password>
```

And ensure you use *--with-dse* when you associate the cluster to the frontend:
```
cstar_docker associate test_frontend test_cluster --with-dse
```