### PR TITLE
Add more schedule comands

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -82,10 +82,10 @@ Your new client public key will be printed on the screen. You need to import thi
     >>> db = Model()
     INFO:cstar_perf.model:Initializing Model...
     INFO:cstar_perf.model:Model initialized
-    >>> db.add_cluster('YOUR_CLUSTER_NAME', 1, 'YOUR_CLUSTER_DESCRIPTION')
+    >>> db.add_cluster('YOUR_CLUSTER_NAME', CLUSTER_HOSTNAMES, 'YOUR_CLUSTER_DESCRIPTION')
     >>> db.add_pub_key('YOUR_CLUSTER_NAME', 'cluster', 'YOUR_CLIENT_PUBLIC_KEY')
 
-Replace YOUR_CLUSTER_NAME with the same cluster name you gave above, and YOUR_CLIENT_PUBLIC_KEY with the generated client key that was printed on your screen.
+Replace YOUR_CLUSTER_NAME with the same cluster name you gave above, CLUSTER_HOSTNAMES is a list containing the hostnames for the Cassandra nodes as defined in `cluster_config.json` and YOUR_CLIENT_PUBLIC_KEY with the generated client key that was printed on your screen.
 
 
 ## Email notifications

--- a/frontend/cstar_perf/frontend/server/model.py
+++ b/frontend/cstar_perf/frontend/server/model.py
@@ -83,8 +83,8 @@ class Model(object):
         'select_test_status_all': "SELECT * FROM test_status WHERE status = ? LIMIT ?",
         'delete_test_status': "DELETE FROM test_status WHERE status= ? AND cluster = ? AND test_id = ?",
         'select_clusters_name': "SELECT name from clusters;",
-        'select_clusters': "SELECT name, description, jvms, num_nodes FROM clusters;",
-        'insert_clusters': "INSERT INTO clusters (name, num_nodes, description) VALUES (?, ?, ?)",
+        'select_clusters': "SELECT name, description, jvms, nodes FROM clusters;",
+        'insert_clusters': "INSERT INTO clusters (name, nodes, description) VALUES (?, ?, ?)",
         'add_cluster_jvm': "UPDATE clusters SET jvms[?]=? WHERE name = ?",
         'insert_user': "INSERT INTO users (user_id, full_name, roles) VALUES (?, ?, ?);",
         'select_user': "SELECT * FROM users WHERE user_id = ?;",
@@ -169,8 +169,8 @@ class Model(object):
         session.execute("CREATE TABLE test_artifacts (test_id timeuuid, artifact_type text, description text, artifact blob, PRIMARY KEY (test_id, artifact_type));")
 
         # Cluster information
-        session.execute("CREATE TABLE clusters (name text PRIMARY KEY, num_nodes int, description text, jvms map<text, text>)")
-        
+        session.execute("CREATE TABLE clusters (name text PRIMARY KEY, nodes list<text>, description text, jvms map<text, text>)")
+
         #Users
         session.execute("CREATE TABLE users (user_id text PRIMARY KEY, full_name text, roles set <text>);")
         #session.execute("INSERT INTO users (user_id, full_name, roles) VALUES ('ryan@datastax.com', 'Ryan McGuire', {'user','admin'});")
@@ -351,9 +351,9 @@ class Model(object):
     ################################################################################
     #### Cluster Management:
     ################################################################################
-    def add_cluster(self, name, num_nodes, description):
+    def add_cluster(self, name, nodes, description):
         session = self.get_session()
-        session.execute(self.__prepared_statements['insert_clusters'], (name, num_nodes, description))
+        session.execute(self.__prepared_statements['insert_clusters'], (name, nodes, description))
 
     def get_cluster_names(self):
         session = self.get_session()
@@ -368,7 +368,7 @@ class Model(object):
             clusters[row[0]] = {'name': row[0],
                                 'description': row[1],
                                 'jvms': dict(row[2]),
-                                'num_nodes' : row[3]}
+                                'nodes' : row[3]}
         return clusters
 
     def add_cluster_jvm(self, cluster, version, path):

--- a/frontend/cstar_perf/frontend/server/model.py
+++ b/frontend/cstar_perf/frontend/server/model.py
@@ -367,7 +367,7 @@ class Model(object):
         for row in rows:
             clusters[row[0]] = {'name': row[0],
                                 'description': row[1],
-                                'jvms': row[2],
+                                'jvms': dict(row[2]),
                                 'num_nodes' : row[3]}
         return clusters
 

--- a/frontend/cstar_perf/frontend/server/templates/schedule.jinja2.html
+++ b/frontend/cstar_perf/frontend/server/templates/schedule.jinja2.html
@@ -62,7 +62,7 @@ label {
 
 <h2>Schedule New Test</h2>
 <hr>
-<form id="schedule-test" class="form-horizontal">
+<form id="schedule-test" class="form-horizontal" novalidate>
   <fieldset>
     <!-- Form Name -->
     <!-- Left Column -->

--- a/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
+++ b/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
@@ -92,6 +92,15 @@ h3 {
       {% if op['command'] %}
         <tr><td>Command</td><td><code>{{op['command']}}</code></td></tr>
       {% endif %}
+      {% if op['script'] %}
+        <tr><td>Script</td><td><code>{{op['script']}}</code></td></tr>
+      {% endif %}
+      {% if op['nodes'] %}
+        <tr><td>Nodes</td><td><code>{{op['nodes']}}</code></td></tr>
+      {% endif %}
+      {% if op['node'] %}
+        <tr><td>node</td><td><code>{{op['node']}}</code></td></tr>
+      {% endif %}
       {% if op.has_key('wait_for_compaction') %}
         <tr><td>wait for compactions</td><td>{{op['wait_for_compaction']}}</td></tr>
       {% endif %}

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -230,6 +230,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "      </div>" +
         "     </div>";
 
+    operationDefaults = operationDefaults || {};
     newOperation = {
         operationType: operationDefaults.operation || "stress",
         operation: schedule.n_operations,

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -131,7 +131,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-nodetool node-select' value='all'>" +
+        "                 class='form-control input-md nodes-nodetool node-select'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -460,14 +460,14 @@ var updateURLBar = function(query) {
 $(document).ready(function() {
     //Add revision button callback:
     $('button#add-revision').click(function(e) {
-        addRevisionDiv(true);
         e.preventDefault();
+        addRevisionDiv(true);
     });
 
     //Add operation button callback:
     $('button#add-operation').click(function(e) {
-        addOperationDiv(true);
         e.preventDefault();
+        addOperationDiv(true);
     });
 
     //Refresh jvm list on cluster selection
@@ -489,6 +489,7 @@ $(document).ready(function() {
     
     //Validate form and submit:
     $("form#schedule-test").submit(function(e) {
+        e.preventDefault();
         var job = createJob();
         console.log(job);
         $.ajax({
@@ -505,7 +506,6 @@ $(document).ready(function() {
             console.log(data);
             alert("error: "+data.status+" "+data.statusText+" "+data.responseText);
         });
-        e.preventDefault();
     });
 
 

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -114,7 +114,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>Stress Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-stress' value='{cmd}' required=''></input>" +
+        "                 class='form-control input-md command-stress' value='{command-stress}' required=''></input>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -123,7 +123,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>Nodetool Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-nodetool' value='' required=''></input>" +
+        "                 class='form-control input-md command-nodetool' value='{command-nodetool}' required=''></input>" +
         "        </div>" + 
         "      </div>" +
         "      <div class='form-group nodes nodetool'>" +
@@ -141,7 +141,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>CQL script</label>  " +
         "        <div class='col-md-9'>" +
         "          <textarea id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-cqlsh' required=''></textarea>" +
+        "                 class='form-control input-md script-cqlsh' required='' value='{script-cqlsh}'></textarea>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes cqlsh'>" +
@@ -149,7 +149,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md node-cqlsh node-select' value='all'>" +
+        "                 class='form-control input-md node-cqlsh node-select'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +
@@ -159,7 +159,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>Bash script</label>  " +
         "        <div class='col-md-9'>" +
         "          <textarea id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-bash' required=''></textarea>" +
+        "                 class='form-control input-md script-bash' required='' value='{script-bash}'></textarea>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes bash'>" +
@@ -167,7 +167,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-cqlsh node-select' value='all'>" +
+        "                 class='form-control input-md nodes-cqlsh node-select'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -235,7 +235,6 @@ var addOperationDiv = function(animate, operationDefaults){
         operationType: operationDefaults.operation || "stress",
         operation: schedule.n_operations,
         operation_id: operation_id,
-        // command_nodetool: operationDefaults.command_nodetool || "status",
     };
     if (newOperation.operationType === 'stress' && operationDefaults.command) {
         newOperation.command_stress = operationDefaults.command

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -330,11 +330,11 @@ var createJob = function() {
         }
         if (op === "nodetool") {
             jobSpec['command'] = operation.find(".command-nodetool").val();
-            jobSpec['nodes'] = operation.find(".nodes-nodetool").val();
+            jobSpec['nodes'] = operation.find(".nodes-nodetool").val() || [];
         }
         if (op === "cqlsh") {
             jobSpec['script'] = operation.find(".script-cqlsh").val();
-            jobSpec['node'] = operation.find(".node-cqlsh").val();
+            jobSpec['node'] = operation.find(".node-cqlsh").val() || [];
         }
         if (op === "bash") {
             jobSpec['script'] = operation.find(".script-bash").val();

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -113,7 +113,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "        for='{operation_id}-command'>Stress Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-stress' value='{command_stress}' required=''></input>" +
+        "                 class='form-control input-md command-stress' value='{command_stress}' required=''>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -122,7 +122,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "        for='{operation_id}-command'>Nodetool Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-nodetool' value='{command_nodetool}' required=''></input>" +
+        "                 class='form-control input-md command-nodetool' value='{command_nodetool}' required=''>" +
         "        </div>" + 
         "      </div>" +
         "      <div class='form-group nodes nodetool'>" +
@@ -140,7 +140,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "        for='{operation_id}-command'>CQL script</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-cqlsh' required='' value='{script_cqlsh}'></input>" +
+        "                 class='form-control input-md script-cqlsh' required='' value='{script_cqlsh}'>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes cqlsh'>" +
@@ -158,7 +158,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "        for='{operation_id}-command'>Bash script</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-bash' required='' value='{script_bash}'></input>" +
+        "                 class='form-control input-md script-bash' required='' value='{script_bash}'>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes bash'>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -264,6 +264,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
     if (wait_for_compaction === false) {
         $("#"+operation_id+"-wait-for-compaction").prop("checked", false);
     }
+    update_node_selections(operation_id)
 };
 
 var createJob = function() {
@@ -368,17 +369,23 @@ var cloneExistingJob = function(job_id) {
    });
 }
 
-var update_node_selections = function(callback) {
+var update_node_selections = function(operation_id, callback) {
+    var changeDivs;
+    if (operation_id == null) {
+        changeDivs = $(".node-select");
+    } else {
+        changeDivs = $("div#" + operation_id).find(".node-select");
+    }
     var cluster = $('#cluster').val();
     $.get('/api/clusters/'+cluster, function(data) {
         //Clear out the node lists and fetch new one:
-        $(".node-select").empty();
+        changeDivs.empty();
         if(data.nodes==null) {
             alert("Warning: cluster '"+ cluster+ "' has no nodes defined.");
             return;
         }
         $.each(data.nodes, function(node, path) {
-            $(".node-select").append($("<option value='"+path+"' selected>"+path+"</option>"));
+            changeDivs.append($("<option value='"+path+"' selected>"+path+"</option>"));
         });
         if (callback != null)
             callback();

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -121,8 +121,10 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <select multiple id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-stress-nodes'></select>" +
+        "          <input id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md command-stress-nodes' value='all'" +
+        "                 disabled=disabled>" +
+        "          </input>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -138,8 +140,10 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <select multiple id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-nodetool-nodes'></select>" +
+        "          <input id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md command-nodetool-nodes' value='all'" +
+        "                 disabled=disabled>" +
+        "          </input>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -153,10 +157,12 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "      </div>" +
         "      <div class='form-group nodes cqlsh'>" +
         "        <label class='col-md-3 control-label'" +
-        "            for='{operation_id}-command'>Node</label>  " +
+        "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <select id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-cqlsh-nodes'></select>" +
+        "          <input id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md command-cqlsh-nodes' value='node1'" +
+        "                 disabled=disabled>" +
+        "          </input>" +
         "        </div>" +
         "      </div>" +
         "            " +
@@ -172,8 +178,10 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <select multiple id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-bash-nodes'></select>" +
+        "          <input id='{operation_id}-nodes'" +
+        "                 class='form-control input-md command-bash-nodes' value='all'" +
+        "                 disabled=disabled>" +
+        "          </input>" +
         "        </div>" +
         "      </div>" +
         "            " +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -306,13 +306,16 @@ var createJob = function() {
     job.operations = [];
     $("#schedule-operations div.operation").each(function(i, operation) {
         operation = $(operation);
-        job.operations[i] = {
+        var jobSpec = {
             operation: operation.find(".type").val(),
         };
-        if (job.operations[i]['operation'] === 'stress') {
-            job.operations[i]['command'] = operation.find(".command").val();
+        var op = jobSpec['operation'];
+        if (op === 'stress') {
+            jobSpec['command'] = operation.find(".command-stress").val();
+            // jobSpec['nodes'] = operation.find(".command-stress-nodes").val()
         }
-        job.operations[i]['wait_for_compaction'] = operation.find(".wait-for-compaction").is(":checked");
+        jobSpec['wait_for_compaction'] = operation.find(".wait-for-compaction").is(":checked");
+        job.operations[i] = jobSpec;
     });
 
     return JSON.stringify(job);

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -166,7 +166,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-cqlsh node-select'>" +
+        "                 class='form-control input-md nodes-bash node-select'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -117,15 +117,6 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "                 class='form-control input-md command-stress' value='{cmd}' required=''></input>" +
         "        </div>" +
         "      </div>" +
-        "      <div class='form-group nodes stress'>" +
-        "        <label class='col-md-3 control-label'" +
-        "            for='{operation_id}-command'>Nodes</label>  " +
-        "        <div class='col-md-9'>" +
-        "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-stress node-select' value='all'>" +
-        "          </select>" +
-        "        </div>" +
-        "      </div>" +
         "      " +
         "      <div class='form-group type nodetool'>" +
         "        <label class='col-md-3 control-label'" +
@@ -140,7 +131,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-stress node-select' value='all'>" +
+        "                 class='form-control input-md nodes-nodetool node-select' value='all'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +
@@ -157,16 +148,15 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-cqlsh'" +
-        "                 disabled=disabled>" +
-        "          </input>" +
+        "          <select id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md node-cqlsh node-select' value='all'>" +
+        "          </select>" +
         "        </div>" +
         "      </div>" +
         "            " +
         "      <div class='form-group type bash'>" +
         "        <label class='col-md-3 control-label'" +
-        "        for='{operation_id}-command'>BASH script</label>  " +
+        "        for='{operation_id}-command'>Bash script</label>  " +
         "        <div class='col-md-9'>" +
         "          <textarea id='{operation_id}-script' type='text'" +
         "                 class='form-control input-md script-bash' required=''></textarea>" +
@@ -176,10 +166,9 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-nodes'" +
-        "                 class='form-control input-md nodes-bash' value='all'" +
-        "                 disabled=disabled>" +
-        "          </input>" +
+        "          <select multiple id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md nodes-cqlsh node-select' value='all'>" +
+        "          </select>" +
         "        </div>" +
         "      </div>" +
         "            " +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -293,13 +293,24 @@ var createJob = function() {
     job.operations = [];
     $("#schedule-operations div.operation").each(function(i, operation) {
         operation = $(operation);
+        var op = operation.find(".type").val()
         var jobSpec = {
-            operation: operation.find(".type").val(),
+            operation: op,
         };
-        var op = jobSpec['operation'];
         if (op === 'stress') {
             jobSpec['command'] = operation.find(".command-stress").val();
-            // jobSpec['nodes'] = operation.find(".command-stress-nodes").val()
+        }
+        if (op === "nodetool") {
+            jobSpec['command'] = operation.find(".command-nodetool").val();
+            jobSpec['nodes'] = operation.find(".nodes-nodetool").val();
+        }
+        if (op === "cqlsh") {
+            jobSpec['script'] = operation.find(".script-cqlsh").val();
+            jobSpec['node'] = operation.find(".node-cqlsh").val();
+        }
+        if (op === "bash") {
+            jobSpec['script'] = operation.find(".script-bash").val();
+            jobSpec['nodes'] = operation.find(".nodes-bash").val();
         }
         jobSpec['wait_for_compaction'] = operation.find(".wait-for-compaction").is(":checked");
         job.operations[i] = jobSpec;

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -121,10 +121,9 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md command-stress-nodes' value='all'" +
-        "                 disabled=disabled>" +
-        "          </input>" +
+        "          <select multiple id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md nodes-stress node-select' value='all'>" +
+        "          </select>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -140,10 +139,9 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md command-nodetool-nodes' value='all'" +
-        "                 disabled=disabled>" +
-        "          </input>" +
+        "          <select multiple id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md nodes-stress node-select' value='all'>" +
+        "          </select>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -160,7 +158,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md command-cqlsh-nodes' value='node1'" +
+        "                 class='form-control input-md nodes-cqlsh'" +
         "                 disabled=disabled>" +
         "          </input>" +
         "        </div>" +
@@ -179,7 +177,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-bash-nodes' value='all'" +
+        "                 class='form-control input-md nodes-bash' value='all'" +
         "                 disabled=disabled>" +
         "          </input>" +
         "        </div>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -291,7 +291,7 @@ var addOperationDiv = function(animate, operationDefaults){
     if (operationDefaults.wait_for_compaction === false) {
         $("#"+operation_id+"-wait-for-compaction").prop("checked", false);
     }
-    update_node_selections(operation_id)
+    update_node_selections(operation_id, operationDefaults)
 };
 
 var createJob = function() {
@@ -396,7 +396,15 @@ var cloneExistingJob = function(job_id) {
    });
 }
 
-var update_node_selections = function(operation_id, callback) {
+var update_node_selections = function(operation_id, operation_defaults, callback) {
+    operation_defaults = operation_defaults || {};
+    var defaultNodeSpec = operation_defaults.nodes;
+    if (!defaultNodeSpec) {
+        if (operation_defaults.node) {
+            var defaultNodeSpec = [operation_defaults.node];
+        }
+    }
+
     var changeDivs;
     if (operation_id == null) {
         changeDivs = $(".node-select");
@@ -412,7 +420,20 @@ var update_node_selections = function(operation_id, callback) {
             return;
         }
         $.each(data.nodes, function(node, path) {
-            changeDivs.append($("<option value='"+path+"' selected>"+path+"</option>"));
+            var newNodeOption = "<option value='"+path+"'";
+            // if the node's name was selected in the default operation, select it here
+            if (defaultNodeSpec) {
+                for (i = 0; i < defaultNodeSpec.length; i++) {
+                    if (defaultNodeSpec[i] === path) {
+                        newNodeOption += " selected";
+                        break;
+                    }
+                }
+            } else {
+                newNodeOption += " selected";
+            }
+            newNodeOption += ">"+path+"</option>";
+            changeDivs.append($(newNodeOption));
         });
         if (callback != null)
             callback();

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -368,6 +368,23 @@ var cloneExistingJob = function(job_id) {
    });
 }
 
+var update_node_selections = function(callback) {
+    var cluster = $('#cluster').val();
+    $.get('/api/clusters/'+cluster, function(data) {
+        //Clear out the node lists and fetch new one:
+        $(".node-select").empty();
+        if(data.nodes==null) {
+            alert("Warning: cluster '"+ cluster+ "' has no nodes defined.");
+            return;
+        }
+        $.each(data.nodes, function(node, path) {
+            $(".node-select").append($("<option value='"+path+"' selected>"+path+"</option>"));
+        });
+        if (callback != null)
+            callback();
+    });
+}
+
 var update_jvm_selections = function(callback) {
     var cluster = $('#cluster').val();
     $.get('/api/clusters/'+cluster, function(data) {
@@ -422,6 +439,7 @@ $(document).ready(function() {
     //Refresh jvm list on cluster selection
     $('#cluster').change(function(e) {
         update_jvm_selections();
+        update_node_selections();
     });
 
     query = parseUri(location).queryKey;


### PR DESCRIPTION
I can squash before merge. At a high level, the changes are:

- There's a small change to the frontend's model of clusters -- instead of knowing the number of nodes, it knows the hostnames of the nodes.
- `addOperationDiv` adds a much bigger `div` that includes input fields for nodetool commands and bash and cqlsh scripts. To accommodate this extra data, the following behaviors have been changed:
  - serialization for posting a job
  - cloning jobs
  - setting default values in `addOperationDiv`
- Where applicable, operations use the names of nodes they operate on, and users can select which nodes they run commands on. All nodes are selected by default.
  - To accomodate this, the `/cluster` endpoint exposes node hostnames. This data is used in a function that updates the values in the node selection input elements.