### PR TITLE
run nodetool on all nodes if no 'nodes' argument

### DIFF
--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -43,7 +43,6 @@ def validate_operations_list(operations):
             assert op.has_key('command'), "Nodetool operation missing comamnd"
             for option in [' -h',' --host']:
                 assert option not in op['command'], "Nodetool command cananot specify the host, use the nodes parameter in the operation instead"
-            assert op.has_key('nodes'), "Nodetool operation missing nodes list"
         elif op['type'] == 'cqlsh':
             assert op.has_key('script'), "Cqlsh operation missing script"
             assert op.has_key('node'), "Cqlsh operation missing node to run on"
@@ -154,6 +153,8 @@ def stress_compare(revisions,
                     wait_for_compaction(compaction_throughput=compaction_throughput)
 
             elif operation['type'] == 'nodetool':
+                if 'nodes' not in operation:
+                    operation['nodes'] = 'all'
                 if operation['nodes'] in ['all','ALL']:
                     nodes = [n for n in fab_config['hosts']]
                 else:


### PR DESCRIPTION
A number of my new regression profiles (see [this branch](https://github.com/mambocab/cstar_perf/tree/regression-tests)) failed with the error `Nodetool operation missing nodes list` (see [here](https://gist.github.com/mambocab/1d735689f19596596061) for links).

This goes against [the documentation for the `nodetool` operation](http://datastax.github.io/cstar_perf/running_tests.html#type-nodetool), which says that it should run on all nodes if `nodes` is not specified. I like the sound of that, so this PR just removes the check for `nodes`, and sets `nodes` to `all` if `nodes` isn't specified. 