### PR TITLE
Leave data benchmark

### DIFF
--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -66,6 +66,14 @@ def bootstrap(cfg=None, destroy=False, leave_data=False, git_fetch=True):
     logger.info("### Config: ###")
     pprint(cstar.config)
 
+    # leave_data settting can be set in the revision
+    # configuration, or manually in the call to this function.
+    # Either is fine, but they shouldn't conflict. If they do,
+    # ValueError is raised.
+    if leave_data == True and cfg.get('leave_data', None) == False:
+        raise ValueError('setting for leave_data conflicts in job config and bootstrap() call')
+    else:
+        leave_data = cfg.get('leave_data', leave_data)
 
     # Set device readahead:
     if cfg['blockdev_readahead'] is not None:

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -97,10 +97,10 @@ def stress_compare(revisions,
     # configuration, or manually in the call to this function. Either
     # is fine, but they shouldn't conflict. If they do, ValueError is
     # raised.
-    if initial_destroy = True and pristine_config.get('initial_destroy', None) == False:
+    if initial_destroy == True and pristine_config.get('initial_destroy', None) == False:
         raise ValueError('setting for initial_destroy conflicts in job config and stress_compare() call')
     else:
-        initial_destroy = pristine_config('initial_destroy', initial_destroy)
+        initial_destroy = pristine_config.get('initial_destroy', initial_destroy)
         
     if initial_destroy:
         logger.info("Cleaning up from prior runs of stress_compare ...")
@@ -119,10 +119,10 @@ def stress_compare(revisions,
         # configuration, or manually in the call to this function.
         # Either is fine, but they shouldn't conflict. If they do,
         # ValueError is raised.
-        if leave_data = True and revision_config.get('leave_data', None) == False:
+        if leave_data == True and revision_config.get('leave_data', None) == False:
             raise ValueError('setting for leave_data conflicts in job config and stress_compare() call')
         else:
-            leave_data = revision_config('leave_data', leave_data)
+            leave_data = revision_config.get('leave_data', leave_data)
                 
         logger.info("Bringing up {revision} cluster...".format(revision=revision))
         

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -114,7 +114,6 @@ def stress_compare(revisions,
         config['title'] = title
         config['subtitle'] = subtitle
 
-
         # leave_data settting can be set in the revision
         # configuration, or manually in the call to this function.
         # Either is fine, but they shouldn't conflict. If they do,
@@ -226,7 +225,10 @@ def stress_compare(revisions,
                            'subtitle': subtitle,
                            'revisions': revisions})
 
-        teardown(destroy=True, leave_data=revisions[-1].get('leave_data', False))
+        if revisions[-1].get('leave_data', False):
+            teardown(destroy=False, leave_data=True)
+        else:
+            teardown(destroy=True, leave_data=False)
 
 def main():
     parser = argparse.ArgumentParser(description='stress_compare')

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -92,7 +92,16 @@ def stress_compare(revisions,
     validate_operations_list(operations)
 
     pristine_config = copy.copy(fab_config)
-    
+
+    # initial_destroy settting can be set in the job
+    # configuration, or manually in the call to this function. Either
+    # is fine, but they shouldn't conflict. If they do, ValueError is
+    # raised.
+    if initial_destroy = True and pristine_config.get('initial_destroy', None) == False:
+        raise ValueError('setting for initial_destroy conflicts in job config and stress_compare() call')
+    else:
+        initial_destroy = pristine_config('initial_destroy', initial_destroy)
+        
     if initial_destroy:
         logger.info("Cleaning up from prior runs of stress_compare ...")
         teardown(destroy=True, leave_data=False)
@@ -105,6 +114,16 @@ def stress_compare(revisions,
         config['title'] = title
         config['subtitle'] = subtitle
 
+
+        # leave_data settting can be set in the revision
+        # configuration, or manually in the call to this function.
+        # Either is fine, but they shouldn't conflict. If they do,
+        # ValueError is raised.
+        if leave_data = True and revision_config.get('leave_data', None) == False:
+            raise ValueError('setting for leave_data conflicts in job config and stress_compare() call')
+        else:
+            leave_data = revision_config('leave_data', leave_data)
+                
         logger.info("Bringing up {revision} cluster...".format(revision=revision))
         
         # Drop the page cache between each revision, especially 
@@ -207,7 +226,7 @@ def stress_compare(revisions,
                            'subtitle': subtitle,
                            'revisions': revisions})
 
-        teardown(destroy=True, leave_data=leave_data)
+        teardown(destroy=True, leave_data=revisions[-1].get('leave_data', False))
 
 def main():
     parser = argparse.ArgumentParser(description='stress_compare')


### PR DESCRIPTION
This supports creating data with one job and then using that same data on a subsequent job.

Example write:
```
{
 "revisions":[
     {"revision":"cassandra-2.1.4", "leave_data":true, "cluster_name": "Test_9619"}
 ],
 "title":"#9619 perf regression - just write with leave_data=True",
 "log":"stats.9619.write.json",
 "operations": [
     {"type":"stress","command":"write n=1M -rate threads=300 -col n=FIXED\\(50\\)",
      "wait_for_compaction":false}
 ]
}
```

Example read:
```
{
 "initial_destroy": false,   
 "revisions":[
     {"revision":"cassandra-2.1.4", "leave_data":true, "cluster_name": "Test_9619"},
     {"revision":"cassandra-2.1.5", "leave_data":true, "cluster_name": "Test_9619"},
     {"revision":"cassandra-2.1.6", "leave_data":true, "cluster_name": "Test_9619"}     
 ],
 "title":"#9619 perf regression - just read after previous write",
 "log":"stats.9619.read.json",
 "operations": [
     {"type":"stress","command":"read n=1M -rate threads=300",
      "wait_for_compaction":false}
 ]
}
```

The key points:

 * You must set the same cluster name on each revision, cstar_perf normally creates a random cluster name, but C* will refuse to startup if the data looks like it's from a different cluster.
 * You must set leave_data:true on each revision you want to preserve the data from that run.
 * You must set initial_destroy:false on the subsequent jobs in order to not destroy the data as one of the initial setup tasks. 
