### PR TITLE
adds revision_override option

### DIFF
--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -123,7 +123,7 @@ def bootstrap(cfg=None, destroy=False, leave_data=False, git_fetch=True):
                 git_ids.update(execute(cstar.bootstrap, git_fetch=git_fetch, revision_override=override_revision))
 
     overridden_host_versions = {}
-    for v, hs in cfg['revision_override'].items():
+    for v, hs in cfg.get('revision_override', {}).items():
         overridden_host_versions.update({h: v for h in hs})
     expected_host_versions = dict({h: cfg['revision'] for h in hosts}, **overridden_host_versions)
     expected_host_shas = {h: str(sh.git('--git-dir={home}/fab/cassandra.git'.format(home=HOME), 'rev-parse', v))

--- a/tool/cstar_perf/tool/fab_cassandra.py
+++ b/tool/cstar_perf/tool/fab_cassandra.py
@@ -249,12 +249,12 @@ def get_cassandra_config_options():
     return [o for o in opts if p.match(o)]
     
 @fab.parallel
-def bootstrap(git_fetch=True):
+def bootstrap(git_fetch=True, revision_override=None):
     """Install and configure Cassandra on each host
     
     Returns the git id for the version checked out.
     """
-    revision = config['revision']
+    revision = revision_override or config['revision']
     partitioner = config['partitioner']
 
     fab.run('mkdir -p fab')
@@ -450,10 +450,12 @@ def start():
 
     # Place environment file on host:
     env = config.get('env', '')
+    fab.puts('env is: {}'.format(env))
 
     if isinstance(env, list) or isinstance(env, tuple):
         env = "\n".join(env)
     env += "\n"
+    fab.puts('env is: {}'.format(env))
     if not config['use_jna']:
         env = 'JVM_EXTRA_OPTS=-Dcassandra.boot_without_jna=true\n\n' + env
     # Turn on GC logging:
@@ -469,6 +471,7 @@ def start():
     fab.run('mkdir -p ~/fab/scripts')
     fab.put(env_file, '~/fab/scripts/{env_script}'.format(env_script=env_script))
 
+    fab.puts('env is: {}'.format(env))
     if len(env_script) > 0:
         fab.run('echo >> ~/fab/scripts/{env_script}'.format(**locals()))
         fab.run('cat ~/fab/cassandra/conf/cassandra-env.sh >> ~/fab/scripts/{env_script}'.format(**locals()))


### PR DESCRIPTION
Allows for installing different C* versions on different hosts. I've been running `cstar_perf_stress` with the following file as input to confirm that it works:

https://gist.githubusercontent.com/mambocab/14fd5367ccd46eacc006/raw/745306fc4a1fdba7dccdec2ebd339592c54faaae/revision_overrides.json

You can look at the `output` section in the `nodetool` report for resulting stats file to confirm that the different nodes are running different versions of C*.

As far as I could tell, the return value from the changed `bootstrap` function isn't used anywhere, so I don't think changing the return type will break anything.