### PR TITLE
Add more schedule commands

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -82,10 +82,10 @@ Your new client public key will be printed on the screen. You need to import thi
     >>> db = Model()
     INFO:cstar_perf.model:Initializing Model...
     INFO:cstar_perf.model:Model initialized
-    >>> db.add_cluster('YOUR_CLUSTER_NAME', 1, 'YOUR_CLUSTER_DESCRIPTION')
+    >>> db.add_cluster('YOUR_CLUSTER_NAME', CLUSTER_HOSTNAMES, 'YOUR_CLUSTER_DESCRIPTION')
     >>> db.add_pub_key('YOUR_CLUSTER_NAME', 'cluster', 'YOUR_CLIENT_PUBLIC_KEY')
 
-Replace YOUR_CLUSTER_NAME with the same cluster name you gave above, and YOUR_CLIENT_PUBLIC_KEY with the generated client key that was printed on your screen.
+Replace YOUR_CLUSTER_NAME with the same cluster name you gave above, CLUSTER_HOSTNAMES is a list containing the hostnames for the Cassandra nodes as defined in `cluster_config.json` and YOUR_CLIENT_PUBLIC_KEY with the generated client key that was printed on your screen.
 
 
 ## Email notifications

--- a/frontend/cstar_perf/frontend/server/model.py
+++ b/frontend/cstar_perf/frontend/server/model.py
@@ -91,8 +91,8 @@ class Model(object):
         'select_test_status_all': "SELECT * FROM test_status WHERE status = ? LIMIT ?",
         'delete_test_status': "DELETE FROM test_status WHERE status= ? AND cluster = ? AND test_id = ?",
         'select_clusters_name': "SELECT name from clusters;",
-        'select_clusters': "SELECT name, description, jvms, num_nodes, additional_products FROM clusters;",
-        'insert_clusters': "INSERT INTO clusters (name, num_nodes, description) VALUES (?, ?, ?)",
+        'select_clusters': "SELECT name, description, jvms, nodes, additional_products FROM clusters;",
+        'insert_clusters': "INSERT INTO clusters (name, nodes, description) VALUES (?, ?, ?)",
         'add_cluster_jvm': "UPDATE clusters SET jvms[?]=? WHERE name = ?",
         'add_cluster_product': "UPDATE clusters SET additional_products=additional_products + ? WHERE name = ?",
         'insert_user': "INSERT INTO users (user_id, full_name, roles) VALUES (?, ?, ?);",
@@ -180,8 +180,8 @@ class Model(object):
         session.execute("CREATE TABLE test_artifacts (test_id timeuuid, artifact_type text, description text, artifact blob, PRIMARY KEY (test_id, artifact_type));")
 
         # Cluster information
-        session.execute("CREATE TABLE clusters (name text PRIMARY KEY, num_nodes int, description text, jvms map<text, text>, additional_products set<text>)")
-        
+        session.execute("CREATE TABLE clusters (name text PRIMARY KEY, nodes list<text>, description text, jvms map<text, text>, additional_products set<text>)")
+
         #Users
         session.execute("CREATE TABLE users (user_id text PRIMARY KEY, full_name text, roles set <text>);")
         session.execute("CREATE TABLE user_passphrase (user_id text PRIMARY KEY, hash text, salt text);")
@@ -363,9 +363,9 @@ class Model(object):
     ################################################################################
     #### Cluster Management:
     ################################################################################
-    def add_cluster(self, name, num_nodes, description):
+    def add_cluster(self, name, nodes, description):
         session = self.get_session()
-        session.execute(self.__prepared_statements['insert_clusters'], (name, num_nodes, description))
+        session.execute(self.__prepared_statements['insert_clusters'], (name, nodes, description))
 
     def get_cluster_names(self):
         session = self.get_session()
@@ -393,7 +393,7 @@ class Model(object):
             clusters[row[0]] = {'name': row[0],
                                 'description': row[1],
                                 'jvms': jvms,
-                                'num_nodes' : row[3],
+                                'nodes' : row[3],
                                 'additional_products' : products}
         return clusters
 

--- a/frontend/cstar_perf/frontend/server/templates/schedule.jinja2.html
+++ b/frontend/cstar_perf/frontend/server/templates/schedule.jinja2.html
@@ -62,7 +62,7 @@ label {
 
 <h2>Schedule New Test</h2>
 <hr>
-<form id="schedule-test" class="form-horizontal">
+<form id="schedule-test" class="form-horizontal" novalidate>
   <fieldset>
     <!-- Form Name -->
     <!-- Left Column -->

--- a/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
+++ b/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
@@ -92,6 +92,15 @@ h3 {
       {% if op['command'] %}
         <tr><td>Command</td><td><code>{{op['command']}}</code></td></tr>
       {% endif %}
+      {% if op['script'] %}
+        <tr><td>Script</td><td><code>{{op['script']}}</code></td></tr>
+      {% endif %}
+      {% if op['nodes'] %}
+        <tr><td>Nodes</td><td><code>{{op['nodes']}}</code></td></tr>
+      {% endif %}
+      {% if op['node'] %}
+        <tr><td>node</td><td><code>{{op['node']}}</code></td></tr>
+      {% endif %}
       {% if op.has_key('wait_for_compaction') %}
         <tr><td>wait for compactions</td><td>{{op['wait_for_compaction']}}</td></tr>
       {% endif %}

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -241,7 +241,6 @@ var addOperationDiv = function(animate, operationDefaults){
         operationType: operationDefaults.operation || "stress",
         operation: schedule.n_operations,
         operation_id: operation_id,
-        // command_nodetool: operationDefaults.command_nodetool || "status",
     };
     if (newOperation.operationType === 'stress' && operationDefaults.command) {
         newOperation.command_stress = operationDefaults.command

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -299,13 +299,24 @@ var createJob = function() {
     job.operations = [];
     $("#schedule-operations div.operation").each(function(i, operation) {
         operation = $(operation);
+        var op = operation.find(".type").val()
         var jobSpec = {
-            operation: operation.find(".type").val(),
+            operation: op,
         };
-        var op = jobSpec['operation'];
         if (op === 'stress') {
             jobSpec['command'] = operation.find(".command-stress").val();
-            // jobSpec['nodes'] = operation.find(".command-stress-nodes").val()
+        }
+        if (op === "nodetool") {
+            jobSpec['command'] = operation.find(".command-nodetool").val();
+            jobSpec['nodes'] = operation.find(".nodes-nodetool").val();
+        }
+        if (op === "cqlsh") {
+            jobSpec['script'] = operation.find(".script-cqlsh").val();
+            jobSpec['node'] = operation.find(".node-cqlsh").val();
+        }
+        if (op === "bash") {
+            jobSpec['script'] = operation.find(".script-bash").val();
+            jobSpec['nodes'] = operation.find(".nodes-bash").val();
         }
         jobSpec['wait_for_compaction'] = operation.find(".wait-for-compaction").is(":checked");
         job.operations[i] = jobSpec;

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -122,15 +122,6 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "                 class='form-control input-md command-stress' value='{cmd}' required=''></input>" +
         "        </div>" +
         "      </div>" +
-        "      <div class='form-group nodes stress'>" +
-        "        <label class='col-md-3 control-label'" +
-        "            for='{operation_id}-command'>Nodes</label>  " +
-        "        <div class='col-md-9'>" +
-        "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-stress node-select' value='all'>" +
-        "          </select>" +
-        "        </div>" +
-        "      </div>" +
         "      " +
         "      <div class='form-group type nodetool'>" +
         "        <label class='col-md-3 control-label'" +
@@ -145,7 +136,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-stress node-select' value='all'>" +
+        "                 class='form-control input-md nodes-nodetool node-select' value='all'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +
@@ -162,16 +153,15 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-cqlsh'" +
-        "                 disabled=disabled>" +
-        "          </input>" +
+        "          <select id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md node-cqlsh node-select' value='all'>" +
+        "          </select>" +
         "        </div>" +
         "      </div>" +
         "            " +
         "      <div class='form-group type bash'>" +
         "        <label class='col-md-3 control-label'" +
-        "        for='{operation_id}-command'>BASH script</label>  " +
+        "        for='{operation_id}-command'>Bash script</label>  " +
         "        <div class='col-md-9'>" +
         "          <textarea id='{operation_id}-script' type='text'" +
         "                 class='form-control input-md script-bash' required=''></textarea>" +
@@ -181,10 +171,9 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-nodes'" +
-        "                 class='form-control input-md nodes-bash' value='all'" +
-        "                 disabled=disabled>" +
-        "          </input>" +
+        "          <select multiple id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md nodes-cqlsh node-select' value='all'>" +
+        "          </select>" +
         "        </div>" +
         "      </div>" +
         "            " +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -136,7 +136,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-nodetool node-select' value='all'>" +
+        "                 class='form-control input-md nodes-nodetool node-select'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -337,11 +337,11 @@ var createJob = function() {
         }
         if (op === "nodetool") {
             jobSpec['command'] = operation.find(".command-nodetool").val();
-            jobSpec['nodes'] = operation.find(".nodes-nodetool").val();
+            jobSpec['nodes'] = operation.find(".nodes-nodetool").val() || [];
         }
         if (op === "cqlsh") {
             jobSpec['script'] = operation.find(".script-cqlsh").val();
-            jobSpec['node'] = operation.find(".node-cqlsh").val();
+            jobSpec['node'] = operation.find(".node-cqlsh").val() || [];
         }
         if (op === "bash") {
             jobSpec['script'] = operation.find(".script-bash").val();

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -517,8 +517,8 @@ $(document).ready(function() {
     } else {
         //Create a new job from scratch:
         addRevisionDiv(false);
-        addOperationDiv(false, {operation: 'stress', command_stress: 'write n=19M -rate threads=50'});
-        addOperationDiv(false, {operation: 'stress', command_stress: 'read n=19M -rate threads=50'});
+        addOperationDiv(false, {operation: 'stress', command: 'write n=19M -rate threads=50'});
+        addOperationDiv(false, {operation: 'stress', command: 'read n=19M -rate threads=50'});
     }
 
     //Validate form and submit:

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -126,8 +126,10 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <select multiple id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-stress-nodes'></select>" +
+        "          <input id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md command-stress-nodes' value='all'" +
+        "                 disabled=disabled>" +
+        "          </input>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -143,8 +145,10 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <select multiple id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-nodetool-nodes'></select>" +
+        "          <input id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md command-nodetool-nodes' value='all'" +
+        "                 disabled=disabled>" +
+        "          </input>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -158,10 +162,12 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "      </div>" +
         "      <div class='form-group nodes cqlsh'>" +
         "        <label class='col-md-3 control-label'" +
-        "            for='{operation_id}-command'>Node</label>  " +
+        "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <select id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-cqlsh-nodes'></select>" +
+        "          <input id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md command-cqlsh-nodes' value='node1'" +
+        "                 disabled=disabled>" +
+        "          </input>" +
         "        </div>" +
         "      </div>" +
         "            " +
@@ -177,8 +183,10 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <select multiple id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-bash-nodes'></select>" +
+        "          <input id='{operation_id}-nodes'" +
+        "                 class='form-control input-md command-bash-nodes' value='all'" +
+        "                 disabled=disabled>" +
+        "          </input>" +
         "        </div>" +
         "      </div>" +
         "            " +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -236,6 +236,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "      </div>" +
         "     </div>";
 
+    operationDefaults = operationDefaults || {};
     newOperation = {
         operationType: operationDefaults.operation || "stress",
         operation: schedule.n_operations,

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -376,7 +376,24 @@ var cloneExistingJob = function(job_id) {
    });
 }
 
-var update_cluster_options = function(callback) {
+var update_node_selections = function(callback) {
+    var cluster = $('#cluster').val();
+    $.get('/api/clusters/'+cluster, function(data) {
+        //Clear out the node lists and fetch new one:
+        $(".node-select").empty();
+        if(data.nodes==null) {
+            alert("Warning: cluster '"+ cluster+ "' has no nodes defined.");
+            return;
+        }
+        $.each(data.nodes, function(node, path) {
+            $(".node-select").append($("<option value='"+path+"' selected>"+path+"</option>"));
+        });
+        if (callback != null)
+            callback();
+    });
+}
+
+var update_jvm_selections = function(callback) {
     var cluster = $('#cluster').val();
     $.get('/api/clusters/'+cluster, function(data) {
 
@@ -435,7 +452,8 @@ $(document).ready(function() {
 
     //Refresh jvm list on cluster selection
     $('#cluster').change(function(e) {
-        update_cluster_options();
+        update_jvm_selections();
+        update_node_selections();
     });
 
     query = parseUri(location).queryKey;

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -312,13 +312,16 @@ var createJob = function() {
     job.operations = [];
     $("#schedule-operations div.operation").each(function(i, operation) {
         operation = $(operation);
-        job.operations[i] = {
+        var jobSpec = {
             operation: operation.find(".type").val(),
         };
-        if (job.operations[i]['operation'] === 'stress') {
-            job.operations[i]['command'] = operation.find(".command").val();
+        var op = jobSpec['operation'];
+        if (op === 'stress') {
+            jobSpec['command'] = operation.find(".command-stress").val();
+            // jobSpec['nodes'] = operation.find(".command-stress-nodes").val()
         }
-        job.operations[i]['wait_for_compaction'] = operation.find(".wait-for-compaction").is(":checked");
+        jobSpec['wait_for_compaction'] = operation.find(".wait-for-compaction").is(":checked");
+        job.operations[i] = jobSpec;
     });
 
     return JSON.stringify(job);

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -143,8 +143,8 @@ var addOperationDiv = function(animate, operationDefaults){
         "        <label class='col-md-3 control-label'" +
         "        for='{operation_id}-command'>CQL script</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-cqlsh' required='' value='{script_cqlsh}'>" +
+        "          <textarea id='{operation_id}-script' type='text'" +
+        "                 class='form-control input-md script-cqlsh' required=''>{script_cqlsh}</textarea>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes cqlsh'>" +
@@ -161,8 +161,8 @@ var addOperationDiv = function(animate, operationDefaults){
         "        <label class='col-md-3 control-label'" +
         "        for='{operation_id}-command'>Bash script</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-bash' required='' value='{script_bash}'>" +
+        "          <textarea id='{operation_id}-script' type='text'" +
+        "                 class='form-control input-md script-bash' required=''>{script_bash}</textarea>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes bash'>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -126,10 +126,9 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md command-stress-nodes' value='all'" +
-        "                 disabled=disabled>" +
-        "          </input>" +
+        "          <select multiple id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md nodes-stress node-select' value='all'>" +
+        "          </select>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -145,10 +144,9 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
-        "          <input id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md command-nodetool-nodes' value='all'" +
-        "                 disabled=disabled>" +
-        "          </input>" +
+        "          <select multiple id='{operation_id}-nodes' type='text'" +
+        "                 class='form-control input-md nodes-stress node-select' value='all'>" +
+        "          </select>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -165,7 +163,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md command-cqlsh-nodes' value='node1'" +
+        "                 class='form-control input-md nodes-cqlsh'" +
         "                 disabled=disabled>" +
         "          </input>" +
         "        </div>" +
@@ -184,7 +182,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-nodes'" +
-        "                 class='form-control input-md command-bash-nodes' value='all'" +
+        "                 class='form-control input-md nodes-bash' value='all'" +
         "                 disabled=disabled>" +
         "          </input>" +
         "        </div>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -96,8 +96,6 @@ var addRevisionDiv = function(animate){
 var addOperationDiv = function(animate, operationDefaults){
     schedule.n_operations++;
     var operation_id = 'operation-'+schedule.n_operations;
-    if (!cmd)
-        cmd = 'write n=19M -rate threads=50';
     var template = "<div id='{operation_id}' class='operation'><legend>Operation<a class='pull-right' id='remove-{operation_id}'><span class='glyphicon" +
         "                  glyphicon-remove'></span></a></legend>" +
         "      <div class='form-group'>" +
@@ -245,7 +243,7 @@ var addOperationDiv = function(animate, operationDefaults){
     if (newOperation.operationType === 'stress' && operationDefaults.command) {
         newOperation.command_stress = operationDefaults.command
     } else {
-        newOperation.command_stress = "write n=19000000 -rate threads=50";
+        newOperation.command_stress = "write n=19M -rate threads=50";
     }
     if (newOperation.operationType === 'nodetool' && operationDefaults.command) {
         newOperation.command_nodetool = operationDefaults.command;
@@ -296,7 +294,7 @@ var addOperationDiv = function(animate, operationDefaults){
     if (operationDefaults.wait_for_compaction === false) {
         $("#"+operation_id+"-wait-for-compaction").prop("checked", false);
     }
-    update_node_selections(operation_id, operationDefaults)
+    update_cluster_options(operation_id, operationDefaults)
 };
 
 var createJob = function() {
@@ -404,7 +402,7 @@ var cloneExistingJob = function(job_id) {
    });
 }
 
-var update_node_selections = function(operation_id, operation_defaults, callback) {
+var update_cluster_options = function(operation_id, operation_defaults, callback) {
     operation_defaults = operation_defaults || {};
     var defaultNodeSpec = operation_defaults.nodes;
     if (!defaultNodeSpec) {
@@ -419,6 +417,7 @@ var update_node_selections = function(operation_id, operation_defaults, callback
     } else {
         changeDivs = $("div#" + operation_id).find(".node-select");
     }
+    
     var cluster = $('#cluster').val();
     $.get('/api/clusters/'+cluster, function(data) {
         //Clear out the node lists and fetch new one:
@@ -508,7 +507,7 @@ $(document).ready(function() {
     //Refresh jvm list on cluster selection
     $('#cluster').change(function(e) {
         update_jvm_selections();
-        update_node_selections();
+        update_cluster_options();
     });
 
     query = parseUri(location).queryKey;

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -269,6 +269,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
     if (wait_for_compaction === false) {
         $("#"+operation_id+"-wait-for-compaction").prop("checked", false);
     }
+    update_node_selections(operation_id)
 };
 
 var createJob = function() {
@@ -376,17 +377,23 @@ var cloneExistingJob = function(job_id) {
    });
 }
 
-var update_node_selections = function(callback) {
+var update_node_selections = function(operation_id, callback) {
+    var changeDivs;
+    if (operation_id == null) {
+        changeDivs = $(".node-select");
+    } else {
+        changeDivs = $("div#" + operation_id).find(".node-select");
+    }
     var cluster = $('#cluster').val();
     $.get('/api/clusters/'+cluster, function(data) {
         //Clear out the node lists and fetch new one:
-        $(".node-select").empty();
+        changeDivs.empty();
         if(data.nodes==null) {
             alert("Warning: cluster '"+ cluster+ "' has no nodes defined.");
             return;
         }
         $.each(data.nodes, function(node, path) {
-            $(".node-select").append($("<option value='"+path+"' selected>"+path+"</option>"));
+            changeDivs.append($("<option value='"+path+"' selected>"+path+"</option>"));
         });
         if (callback != null)
             callback();

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -119,7 +119,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>Stress Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-stress' value='{cmd}' required=''></input>" +
+        "                 class='form-control input-md command-stress' value='{command-stress}' required=''></input>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -128,7 +128,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>Nodetool Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-nodetool' value='' required=''></input>" +
+        "                 class='form-control input-md command-nodetool' value='{command-nodetool}' required=''></input>" +
         "        </div>" + 
         "      </div>" +
         "      <div class='form-group nodes nodetool'>" +
@@ -146,7 +146,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>CQL script</label>  " +
         "        <div class='col-md-9'>" +
         "          <textarea id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-cqlsh' required=''></textarea>" +
+        "                 class='form-control input-md script-cqlsh' required='' value='{script-cqlsh}'></textarea>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes cqlsh'>" +
@@ -154,7 +154,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md node-cqlsh node-select' value='all'>" +
+        "                 class='form-control input-md node-cqlsh node-select'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +
@@ -164,7 +164,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>Bash script</label>  " +
         "        <div class='col-md-9'>" +
         "          <textarea id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-bash' required=''></textarea>" +
+        "                 class='form-control input-md script-bash' required='' value='{script-bash}'></textarea>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes bash'>" +
@@ -172,7 +172,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-cqlsh node-select' value='all'>" +
+        "                 class='form-control input-md nodes-cqlsh node-select'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -107,18 +107,78 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "          <select id='{operation_id}-type'" +
         "                  class='form-control type'>" +
         "            <option value='stress'>stress</option>" +
-        "            <option value='flush'>flush</option>" +
-        "            <option value='compact'>compact</option>" +
+        "            <option value='nodetool'>nodetool</option>" +
+        "            <option value='cqlsh'>cqlsh</option>" +
+        "            <option value='bash'>bash</option>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +
         "      " +
-        "      <div class='form-group stress'>" +
+        "      <div class='form-group type stress'>" +
         "        <label class='col-md-3 control-label'" +
         "        for='{operation_id}-command'>Stress Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command' value='{cmd}' required=''></input>" +
+        "                 class='form-control input-md command-stress' value='{cmd}' required=''></input>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group nodes stress'>" +
+        "        <label class='col-md-3 control-label'" +
+        "            for='{operation_id}-command'>Nodes</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <select multiple id='{operation_id}-nodes'" +
+        "                 class='form-control input-md command-stress-nodes'></select>" +
+        "        </div>" +
+        "      </div>" +
+        "      " +
+        "      <div class='form-group type nodetool'>" +
+        "        <label class='col-md-3 control-label'" +
+        "        for='{operation_id}-command'>Nodetool Command</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <input id='{operation_id}-command' type='text'" +
+        "                 class='form-control input-md command-nodetool' value='' required=''></input>" +
+        "        </div>" + 
+        "      </div>" +
+        "      <div class='form-group nodes nodetool'>" +
+        "        <label class='col-md-3 control-label'" +
+        "            for='{operation_id}-command'>Nodes</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <select multiple id='{operation_id}-nodes'" +
+        "                 class='form-control input-md command-nodetool-nodes'></select>" +
+        "        </div>" +
+        "      </div>" +
+        "      " +
+        "      <div class='form-group type cqlsh'>" +
+        "        <label class='col-md-3 control-label'" +
+        "        for='{operation_id}-command'>CQL script</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <textarea id='{operation_id}-script' type='text'" +
+        "                 class='form-control input-md script-cqlsh' required=''></textarea>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group nodes cqlsh'>" +
+        "        <label class='col-md-3 control-label'" +
+        "            for='{operation_id}-command'>Node</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <select id='{operation_id}-nodes'" +
+        "                 class='form-control input-md command-cqlsh-nodes'></select>" +
+        "        </div>" +
+        "      </div>" +
+        "            " +
+        "      <div class='form-group type bash'>" +
+        "        <label class='col-md-3 control-label'" +
+        "        for='{operation_id}-command'>BASH script</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <textarea id='{operation_id}-script' type='text'" +
+        "                 class='form-control input-md script-bash' required=''></textarea>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group nodes bash'>" +
+        "        <label class='col-md-3 control-label'" +
+        "            for='{operation_id}-command'>Nodes</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <select multiple id='{operation_id}-nodes'" +
+        "                 class='form-control input-md command-bash-nodes'></select>" +
         "        </div>" +
         "      </div>" +
         "            " +
@@ -131,7 +191,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "            <label for='{operation_id}-wait-for-compaction'>" +
         "              Wait for compactions before next operation" +
         "            </label>" +
-        "	  </div>" +
+        "   </div>" +
         "        </div>" +
         "      </div>" +
         "            " +
@@ -175,7 +235,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "                 <input disabled=disabled id='{revision_id}-kill-nodes-delay' class='kill-nodes-delay' value='300'/> seconds" +
         "              </td></tr>" +
         "           </table>" +
-        "	    </div>" +
+        "     </div>" +
         "        </div>" +
 
         "      </div>" +
@@ -186,10 +246,18 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         newDiv.hide();
     $("#schedule-operations").append(newDiv);
     $("#"+operation_id+"-type").change(function(){
-        if (this.value == 'stress') {
-            $("#"+operation_id+" div.stress").show();
-        } else {
-            $("#"+operation_id+" div.stress").hide();
+        var validOperations = ['stress', 'nodetool', 'cqlsh', 'bash'];
+        if (validOperations.indexOf(this.value) < 0) {
+            console.log(this.value + ' not a valid selection')
+        }
+        for (var i = 0; i < validOperations.length; i++) {
+            var op = validOperations[i];
+            var selected = $("#"+operation_id+" div."+op);
+            if (op === this.value) {
+                selected.show();
+            } else {
+                selected.hide();
+            }
         }
     }).val(operation).change();
     if (animate)

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -475,14 +475,14 @@ var updateURLBar = function(query) {
 $(document).ready(function() {
     //Add revision button callback:
     $('button#add-revision').click(function(e) {
-        addRevisionDiv(true);
         e.preventDefault();
+        addRevisionDiv(true);
     });
 
     //Add operation button callback:
     $('button#add-operation').click(function(e) {
-        addOperationDiv(true);
         e.preventDefault();
+        addOperationDiv(true);
     });
 
     //Refresh jvm list on cluster selection
@@ -504,6 +504,7 @@ $(document).ready(function() {
 
     //Validate form and submit:
     $("form#schedule-test").submit(function(e) {
+        e.preventDefault();
         var job = createJob();
         console.log(job);
         $.ajax({
@@ -520,7 +521,6 @@ $(document).ready(function() {
             console.log(data);
             alert("error: "+data.status+" "+data.statusText+" "+data.responseText);
         });
-        e.preventDefault();
     });
 
 

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -172,7 +172,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "            for='{operation_id}-command'>Nodes</label>  " +
         "        <div class='col-md-9'>" +
         "          <select multiple id='{operation_id}-nodes' type='text'" +
-        "                 class='form-control input-md nodes-cqlsh node-select'>" +
+        "                 class='form-control input-md nodes-bash node-select'>" +
         "          </select>" +
         "        </div>" +
         "      </div>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -119,7 +119,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "        for='{operation_id}-command'>Stress Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-stress' value='{command_stress}' required=''></input>" +
+        "                 class='form-control input-md command-stress' value='{command_stress}' required=''>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -128,7 +128,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "        for='{operation_id}-command'>Nodetool Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-nodetool' value='{command_nodetool}' required=''></input>" +
+        "                 class='form-control input-md command-nodetool' value='{command_nodetool}' required=''>" +
         "        </div>" + 
         "      </div>" +
         "      <div class='form-group nodes nodetool'>" +
@@ -146,7 +146,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "        for='{operation_id}-command'>CQL script</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-cqlsh' required='' value='{script_cqlsh}'></input>" +
+        "                 class='form-control input-md script-cqlsh' required='' value='{script_cqlsh}'>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes cqlsh'>" +
@@ -164,7 +164,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "        for='{operation_id}-command'>Bash script</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-bash' required='' value='{script_bash}'></input>" +
+        "                 class='form-control input-md script-bash' required='' value='{script_bash}'>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes bash'>" +

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -93,7 +93,7 @@ var addRevisionDiv = function(animate){
 
 };
 
-var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
+var addOperationDiv = function(animate, operationDefaults){
     schedule.n_operations++;
     var operation_id = 'operation-'+schedule.n_operations;
     if (!cmd)
@@ -119,7 +119,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>Stress Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-stress' value='{command-stress}' required=''></input>" +
+        "                 class='form-control input-md command-stress' value='{command_stress}' required=''></input>" +
         "        </div>" +
         "      </div>" +
         "      " +
@@ -128,7 +128,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        for='{operation_id}-command'>Nodetool Command</label>  " +
         "        <div class='col-md-9'>" +
         "          <input id='{operation_id}-command' type='text'" +
-        "                 class='form-control input-md command-nodetool' value='{command-nodetool}' required=''></input>" +
+        "                 class='form-control input-md command-nodetool' value='{command_nodetool}' required=''></input>" +
         "        </div>" + 
         "      </div>" +
         "      <div class='form-group nodes nodetool'>" +
@@ -145,8 +145,8 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "        for='{operation_id}-command'>CQL script</label>  " +
         "        <div class='col-md-9'>" +
-        "          <textarea id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-cqlsh' required='' value='{script-cqlsh}'></textarea>" +
+        "          <input id='{operation_id}-script' type='text'" +
+        "                 class='form-control input-md script-cqlsh' required='' value='{script_cqlsh}'></input>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes cqlsh'>" +
@@ -163,8 +163,8 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "        <label class='col-md-3 control-label'" +
         "        for='{operation_id}-command'>Bash script</label>  " +
         "        <div class='col-md-9'>" +
-        "          <textarea id='{operation_id}-script' type='text'" +
-        "                 class='form-control input-md script-bash' required='' value='{script-bash}'></textarea>" +
+        "          <input id='{operation_id}-script' type='text'" +
+        "                 class='form-control input-md script-bash' required='' value='{script_bash}'></input>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes bash'>" +
@@ -236,7 +236,34 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
         "      </div>" +
         "     </div>";
 
-    var newDiv = $(template.format({operation:schedule.n_operations, operation_id:operation_id, cmd:cmd}));
+    newOperation = {
+        operationType: operationDefaults.operation || "stress",
+        operation: schedule.n_operations,
+        operation_id: operation_id,
+        // command_nodetool: operationDefaults.command_nodetool || "status",
+    };
+    if (newOperation.operationType === 'stress' && operationDefaults.command) {
+        newOperation.command_stress = operationDefaults.command
+    } else {
+        newOperation.command_stress = "write n=19000000 -rate threads=50";
+    }
+    if (newOperation.operationType === 'nodetool' && operationDefaults.command) {
+        newOperation.command_nodetool = operationDefaults.command;
+    } else {
+        newOperation.command_nodetool = "status";
+    }
+    if (newOperation.operationType === 'cqlsh' && operationDefaults.script) {
+        newOperation.script_cqlsh = operationDefaults.script;
+    } else {
+        newOperation.script_cqlsh = "DESCRIBE TABLES;";
+    }
+    if (newOperation.operationType === 'bash' && operationDefaults.script) {
+        newOperation.script_bash = operationDefaults.script;
+    } else {
+        newOperation.script_bash = "ls";
+    }
+
+    var newDiv = $(template.format(newOperation));
     if (animate)
         newDiv.hide();
     $("#schedule-operations").append(newDiv);
@@ -254,7 +281,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
                 selected.hide();
             }
         }
-    }).val(operation).change();
+    }).val(newOperation.operationType).change();
     if (animate)
         newDiv.slideDown();
 
@@ -266,7 +293,7 @@ var addOperationDiv = function(animate, operation, cmd, wait_for_compaction){
     });
 
     //Check wait_for_compaction box:
-    if (wait_for_compaction === false) {
+    if (operationDefaults.wait_for_compaction === false) {
         $("#"+operation_id+"-wait-for-compaction").prop("checked", false);
     }
     update_node_selections(operation_id)
@@ -366,7 +393,7 @@ var cloneExistingJob = function(job_id) {
         });
         //Operations:
         $.each(test['operations'], function(i, operation) {
-            addOperationDiv(false, operation['operation'], operation['command'], operation['wait_for_compaction']);
+            addOperationDiv(false, operation);
         });
 
         query = parseUri(location).queryKey;
@@ -453,7 +480,7 @@ $(document).ready(function() {
 
     //Add operation button callback:
     $('button#add-operation').click(function(e) {
-        addOperationDiv(true, 'stress');
+        addOperationDiv(true);
         e.preventDefault();
     });
 
@@ -470,8 +497,8 @@ $(document).ready(function() {
     } else {
         //Create a new job from scratch:
         addRevisionDiv(false);
-        addOperationDiv(false, 'stress', 'write n=19M -rate threads=50');
-        addOperationDiv(false, 'stress', 'read n=19M -rate threads=50');
+        addOperationDiv(false, {operation: 'stress', command_stress: 'write n=19M -rate threads=50'});
+        addOperationDiv(false, {operation: 'stress', command_stress: 'read n=19M -rate threads=50'});
     }
 
     //Validate form and submit:

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -297,7 +297,7 @@ var addOperationDiv = function(animate, operationDefaults){
     if (operationDefaults.wait_for_compaction === false) {
         $("#"+operation_id+"-wait-for-compaction").prop("checked", false);
     }
-    update_node_selections(operation_id)
+    update_node_selections(operation_id, operationDefaults)
 };
 
 var createJob = function() {
@@ -405,7 +405,15 @@ var cloneExistingJob = function(job_id) {
    });
 }
 
-var update_node_selections = function(operation_id, callback) {
+var update_node_selections = function(operation_id, operation_defaults, callback) {
+    operation_defaults = operation_defaults || {};
+    var defaultNodeSpec = operation_defaults.nodes;
+    if (!defaultNodeSpec) {
+        if (operation_defaults.node) {
+            var defaultNodeSpec = [operation_defaults.node];
+        }
+    }
+
     var changeDivs;
     if (operation_id == null) {
         changeDivs = $(".node-select");
@@ -421,7 +429,20 @@ var update_node_selections = function(operation_id, callback) {
             return;
         }
         $.each(data.nodes, function(node, path) {
-            changeDivs.append($("<option value='"+path+"' selected>"+path+"</option>"));
+            var newNodeOption = "<option value='"+path+"'";
+            // if the node's name was selected in the default operation, select it here
+            if (defaultNodeSpec) {
+                for (i = 0; i < defaultNodeSpec.length; i++) {
+                    if (defaultNodeSpec[i] === path) {
+                        newNodeOption += " selected";
+                        break;
+                    }
+                }
+            } else {
+                newNodeOption += " selected";
+            }
+            newNodeOption += ">"+path+"</option>";
+            changeDivs.append($(newNodeOption));
         });
         if (callback != null)
             callback();

--- a/frontend/cstar_perf/frontend/static/js/util.js
+++ b/frontend/cstar_perf/frontend/static/js/util.js
@@ -71,10 +71,14 @@ function update_select_with_values(element, values, context) {
         el.append($("<option value='"+val+"'>"+key+"</option>"));
     });
 
+    var default_selections = [];
+
     //Try to set the one we had from before:
     el.each(function(i, e) {
+        default_selections[i] = true;
         if (current_selections[i] != null) {
             $(e).val(current_selections[i]);
+            default_selections[i] = false;
         }
         if ($(e).val() == null) {
             $(e).find("option:first-child").attr("selected", "selected");
@@ -82,6 +86,7 @@ function update_select_with_values(element, values, context) {
         }
     });
 
+    return default_selections;
 }
 
 $(document).ready(function() {

--- a/tool/cstar_perf/docker/cstar_docker.py
+++ b/tool/cstar_perf/docker/cstar_docker.py
@@ -542,9 +542,9 @@ def associate(frontend_name, cluster_names, with_dse=False):
         frontend_credentials = fab_execute(fab_deploy.get_frontend_credentials).values()[0]
 
     for cluster in clusters:
-        num_nodes = len(cluster)-1
         cluster = cluster
         cluster_name = cluster['Config']['Labels']['cluster_name']
+        nodes = get_clusters(c)[cluster_name][1:]
         cluster_ip = cluster['NetworkSettings']['IPAddress']
         with fab.settings(hosts=cluster_ip):
             fab_execute(fab_deploy.generate_client_credentials, cluster_name,
@@ -556,7 +556,7 @@ def associate(frontend_name, cluster_names, with_dse=False):
 
         # Link the cluster to the frontend
         with fab.settings(hosts=frontend_ip):
-            fab_execute(fab_deploy.add_cluster_to_frontend, cluster_name, num_nodes,
+            fab_execute(fab_deploy.add_cluster_to_frontend, cluster_name, nodes,
                         cluster_credentials['public_key'])
             for jvm in jvms:
                 fab_execute(fab_deploy.add_jvm_to_cluster, cluster_name, jvm)

--- a/tool/cstar_perf/tool/fab_deploy.py
+++ b/tool/cstar_perf/tool/fab_deploy.py
@@ -132,15 +132,15 @@ def create_default_frontend_users():
     """
     run_python_script(create_users_script)
 
-def add_cluster_to_frontend(cluster_name, num_nodes, public_key):
+def add_cluster_to_frontend(cluster_name, nodes, public_key):
     """Add the cluster to the frontend configuration"""
 
     add_cluster_script = """
     from cstar_perf.frontend.server.model import Model
     db = Model()
-    db.add_cluster('{name}', {num_nodes}, '{name}')
+    db.add_cluster('{name}', {nodes}, '{name}')
     db.add_pub_key('{name}', 'cluster', '{key}', replace=True)
-    """.format(name=cluster_name, num_nodes=num_nodes, key=public_key)
+    """.format(name=cluster_name, nodes=nodes, key=public_key)
     run_python_script(add_cluster_script)
 
 def add_jvm_to_cluster(cluster_name, jvm):


### PR DESCRIPTION
This pulls @mambocab's add-more-schedule-commands branch into this repository and rebases off of master.

Original description:

- There's a small change to the frontend's model of clusters -- instead of knowing the number of nodes, it knows the hostnames of the nodes.
- `addOperationDiv` adds a much bigger `div` that includes input fields for nodetool commands and bash and cqlsh scripts. To accommodate this extra data, the following behaviors have been changed:
  - serialization for posting a job
  - cloning jobs
  - setting default values in `addOperationDiv`
- Where applicable, operations use the names of nodes they operate on, and users can select which nodes they run commands on. All nodes are selected by default.
  - To accomodate this, the `/cluster` endpoint exposes node hostnames. This data is used in a function that updates the values in the node selection input elements.