### PR TITLE
allow no product key in cluster config

### DIFF
--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -124,7 +124,7 @@ def stress_compare(revisions,
         config['log'] = log
         config['title'] = title
         config['subtitle'] = subtitle
-        product = dse if config['product'] == 'dse' else cstar
+        product = dse if config.get('product') == 'dse' else cstar
 
         # leave_data settting can be set in the revision
         # configuration, or manually in the call to this function.


### PR DESCRIPTION
I haven't dug into this very far in case there's a different problem or an environment error, but: my regression jobs on cstar.datastax.com are failing with a key error when `stress_compare` looks for a `product` key in a config dictionary. I believe that config dictionary is derived from `cluster_config.json`, so this may be an environment error. If having jobs fail when this isn't present in the config isn't what we want, this change should effectively set the default product to `cstar`.