### PR TITLE
Initial flamegraph implementation

### DIFF
--- a/frontend/cstar_perf/frontend/migrations/0002.cql
+++ b/frontend/cstar_perf/frontend/migrations/0002.cql
@@ -1,0 +1,50 @@
+CREATE TABLE cstar_perf.test_artifacts_backup (
+    test_id timeuuid,
+    artifact_type text,
+    artifact blob,
+    description text,
+    PRIMARY KEY (test_id, artifact_type)
+) WITH CLUSTERING ORDER BY (artifact_type ASC)
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99.0PERCENTILE';
+
+COPY cstar_perf.test_artifacts TO '/tmp/test_artifacts';
+
+# DONT FORGET TO SET '[csv] field_size_limit=1000000000' in ~/.cassandra/cqlshrc
+COPY cstar_perf.test_artifacts_backup FROM '/tmp/test_artifacts';
+
+DROP TABLE cstar_perf.test_artifacts;
+
+CREATE TABLE cstar_perf.test_artifacts (
+    test_id timeuuid,
+    artifact_type text,
+    artifact blob,
+    name text,
+    PRIMARY KEY (test_id, artifact_type, name)
+) WITH CLUSTERING ORDER BY (artifact_type ASC)
+    AND bloom_filter_fp_chance = 0.01
+    AND caching = '{"keys":"ALL", "rows_per_partition":"NONE"}'
+    AND comment = ''
+    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
+    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+    AND dclocal_read_repair_chance = 0.1
+    AND default_time_to_live = 0
+    AND gc_grace_seconds = 864000
+    AND max_index_interval = 2048
+    AND memtable_flush_period_in_ms = 0
+    AND min_index_interval = 128
+    AND read_repair_chance = 0.0
+    AND speculative_retry = '99.0PERCENTILE';
+
+COPY cstar_perf.test_artifacts (test_id, artifact_type, artifact, name) FROM '/tmp/test_artifacts';

--- a/frontend/cstar_perf/frontend/server/templates/flamegraph.jinja2.html
+++ b/frontend/cstar_perf/frontend/server/templates/flamegraph.jinja2.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+</head>
+<body>
+
+  <h1><center>FlameGraph</center></h1>
+
+  {% for artifact in artifacts %}
+     <h2>{{ artifact['name'] }}</h2>
+     {{ artifact['data']|safe }}
+  {% endfor %}
+
+</body>
+</html>

--- a/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
+++ b/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
@@ -45,18 +45,36 @@ h3 {
 {% endif %}
 <tr><td>Number of nodes</td><td>{{test['test_definition']['num_nodes']}}</td></tr>
 {% if has_chart %}
-<tr><td>Chart</td><td><a class='btn btn-primary' role='button' href="/tests/artifacts/{{test['test_id']}}/graph">View Chart</a></td></tr>
+<tr>
+  <td>Chart</td>
+  <td>
+    <a class='btn btn-primary' role='button' href="/tests/artifacts/{{test['test_id']}}/graph">View Chart</a>
+    <a class='btn btn-primary' role='button' href="/tests/artifacts/{{test['test_id']}}/flamegraph">Flamegraph</a>
+  </td>
+</tr>
 {% endif %}
 {% if artifacts|length > 0 %}
 <tr><th colspan="100%">Artifacts</th></tr>
 <tr><td colspan="100%"><table id="artifacts_tbl" class='col-md-12'>
   {% for artifact in artifacts %}
    {% if artifact['artifact_type'] in ('failure',) %}
-     <tr><td class='col-md-2'>{{artifact['artifact_type']}}</td><td><pre>{{artifact['artifact']}}</pre></td><td></b></td></tr>
+     <tr>
+       <td class='col-md-2'>{{artifact['artifact_type']}}</td>
+       <td><pre>{{artifact['artifact']}}</pre></td>
+       <td></b></td>
+    </tr>
    {% elif artifact['artifact_type'] in ('link',) %}
-     <tr><td class='col-md-2'>{{artifact['artifact_type']}}</td><td><a href='{{artifact['artifact']}}'>{{artifact['description']}}</a></td><td></td></tr>
+     <tr>
+       <td class='col-md-2'>{{artifact['artifact_type']}}</td>
+       <td><a href='{{artifact['artifact']}}'>{{artifact['name']}}</a></td>
+       <td></td>
+     </tr>
    {% else %}
-     <tr><td class='col-md-2'>{{artifact['artifact_type']}}</td><td><a href='/tests/artifacts/{{test['test_id']}}/{{artifact['artifact_type']}}'>{{artifact['description']}}</a></td><td></td></tr>
+     <tr>
+       <td class='col-md-2'>{{artifact['artifact_type']}}</td>
+       <td><a href='/tests/artifacts/{{test['test_id']}}/{{artifact['artifact_type']}}/{{artifact['name']}}'>{{artifact['name']}}</a></td>
+       <td></td>
+     </tr>
    {% endif %} 
   {% endfor %}
 </td></tr></table>

--- a/frontend/cstar_perf/frontend/server/tests/test_model.py
+++ b/frontend/cstar_perf/frontend/server/tests/test_model.py
@@ -123,9 +123,9 @@ class TestModel(unittest.TestCase):
         a2 = m.update_test_artifact(test_id, 'logs-2', 'LOG data 2', 'more logs')
         a3 = m.update_test_artifact(test_id, 'graph', 'GRAPH data 1', 'stats.json')
 
-        artifact_meta = m.get_test_artifact(test_id, 'logs')
+        artifact_meta = m.get_test_artifact(test_id, 'logs', 'logs.tar.gz')
         self.assertEqual(artifact_meta['artifact_type'], 'logs')
-        artifact_meta = m.get_test_artifact(test_id, 'graph')
+        artifact_meta = m.get_test_artifact(test_id, 'graph', 'stats.json')
         self.assertEqual(artifact_meta['artifact_type'], 'graph')
 
         artifact_meta = m.get_test_artifacts(test_id)
@@ -134,15 +134,15 @@ class TestModel(unittest.TestCase):
         self.assertEqual(artifact_meta[1]['artifact_type'], 'logs')
         self.assertEqual(artifact_meta[2]['artifact_type'], 'logs-2')
 
-        artifact = m.get_test_artifact_data(test_id, 'logs')
+        artifact = m.get_test_artifact_data(test_id, 'logs', 'logs.tar.gz')
         self.assertEqual(artifact.artifact, 'LOG data 1')
-        self.assertEqual(artifact.description, 'logs.tar.gz')
-        artifact = m.get_test_artifact_data(test_id, 'logs-2')
+        self.assertEqual(artifact.name, 'logs.tar.gz')
+        artifact = m.get_test_artifact_data(test_id, 'logs-2', 'more logs')
         self.assertEqual(artifact.artifact, 'LOG data 2')
-        self.assertEqual(artifact.description, 'more logs')
-        artifact = m.get_test_artifact_data(test_id, 'graph')
+        self.assertEqual(artifact.name, 'more logs')
+        artifact = m.get_test_artifact_data(test_id, 'graph', 'stats.json')
         self.assertEqual(artifact.artifact, 'GRAPH data 1')
-        self.assertEqual(artifact.description, 'stats.json')
+        self.assertEqual(artifact.name, 'stats.json')
 
     def test_clusters(self):
         m = self.model

--- a/frontend/cstar_perf/frontend/static/graph/js/graph.js
+++ b/frontend/cstar_perf/frontend/static/graph/js/graph.js
@@ -7,7 +7,7 @@ var drawGraph = function() {
     //Dataset and metric to draw is passed via query option:
     query = parseUri(location).queryKey;
     query.stats = unescape(query.stats);
-    stats_db = '/tests/artifacts/' + query.stats + '/stats';
+    stats_db = '/tests/artifacts/' + query.stats + '/stats/stats.' + query.stats + '.json';
     var metric = query.metric;
     var operation = query.operation;
     var smoothing = query.smoothing;
@@ -317,7 +317,7 @@ var drawGraph = function() {
                     return d.intervals[0][time_index];
                 }
             };
-            
+
             if (rendering_series_graph) {
                 query.xmin = xmin = query.xmin ? query.xmin : d3.min(data, getMinX);
                 query.xmax = xmax = query.xmax ? query.xmax : d3.max(data, getMaxX);
@@ -372,7 +372,7 @@ var drawGraph = function() {
         });
 
         //Setup chart:
-        if (rendering_series_graph) 
+        if (rendering_series_graph)
         {
             var margin = {top: 20, right: 1180, bottom: 2240, left: 60};
             var width = 2060 - margin.left - margin.right;
@@ -680,4 +680,3 @@ $(document).ready(function(){
     drawGraph();
 
 });
-

--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -27,6 +27,7 @@ import shutil
 import fab_common as common
 import fab_dse as dse
 import fab_cassandra as cstar
+import fab_flamegraph as flamegraph
 
 # Then import our cluster specific config:
 from cluster_config import config
@@ -471,6 +472,10 @@ def retrieve_fincore_logs(local_directory):
     """Retrieve each node's fincore logs to the given local directory."""
     execute(common.copy_fincore_logs, local_directory=local_directory)
 
+def retrieve_flamegraph(local_directory, rev_num):
+    """Retrieve each node's flamegraph data and svg to the given local directory."""
+    execute(flamegraph.copy_flamegraph, local_directory=local_directory, rev_num=rev_num)
+
 def start_fincore_capture(interval=10):
     """Start linux-fincore monitoring of Cassandra data files on each node"""
     execute(common.start_fincore_capture, interval=interval)
@@ -510,4 +515,3 @@ def log_stats(stats, memo=None, file='stats.json'):
 
     with open(file, 'w') as f:
         f.write(log)
-

--- a/tool/cstar_perf/tool/fab_flamegraph.py
+++ b/tool/cstar_perf/tool/fab_flamegraph.py
@@ -1,0 +1,124 @@
+"""
+Fabric file to bootstrap Profiling Flamegraph on a set of nodes
+"""
+
+import os
+import logging
+import time
+import sh
+from fabric import api as fab
+
+logging.basicConfig()
+logger = logging.getLogger('flamegraph')
+logger.setLevel(logging.INFO)
+
+# used internally, perf recording is stopped using SIGINT
+PERF_RECORDING_DURATION = 432000  # 5 days
+common_module = None
+
+
+def set_common_module(module):
+    global common_module
+    common_module = module
+
+
+def is_enabled(revision_config=None):
+    is_compatible = True
+    is_enabled = common_module.config.get('flamegraph', False)
+    if revision_config:
+        jvm = revision_config.get('java_home', '')
+        if jvm.find('1.7') != -1:
+            logger.info('Flamegraph is not compatible with java <1.8')
+            is_compatible = False
+    return is_enabled and is_compatible
+
+
+def get_flamegraph_paths():
+    perf_map_agent_path = os.path.expanduser('~/fab/perf-map-agent')
+    flamegraph_path = os.path.expanduser('~/fab/flamegraph')
+
+    return (perf_map_agent_path, flamegraph_path)
+
+
+def get_flamegraph_directory():
+    return common_module.config.get('flamegraph_directory', '/tmp/flamegraph')
+
+
+@fab.parallel
+def copy_flamegraph(local_directory, rev_num):
+    logger.info("Copying Flamegraph data")
+    cfg = common_module.config['hosts'][fab.env.host]
+    host_log_dir = os.path.join(local_directory, cfg['hostname'])
+    flamegraph_directory = get_flamegraph_directory()
+    os.makedirs(host_log_dir)
+    fab.get(os.path.join(flamegraph_directory, 'flamegraph_revision_{}.svg'.format(rev_num)), host_log_dir)
+    fab.get(os.path.join(flamegraph_directory, 'perf_revision_{}.data'.format(rev_num)), host_log_dir)
+
+
+@fab.parallel
+def setup():
+    logger.info("Setup Flamegraph dependencies")
+    perf_map_agent_path, flamegraph_path = get_flamegraph_paths()
+
+    # Create the flamegraph directory and clean the directory
+    flamegraph_directory = get_flamegraph_directory()
+    if not os.path.exists(flamegraph_directory):
+        os.mkdir(flamegraph_directory)
+    for f in os.listdir(flamegraph_directory):
+        file_path = os.path.join(flamegraph_directory, f)
+        sh.sudo.rm(file_path)
+
+    if not os.path.exists(perf_map_agent_path):
+        sh.git('clone', 'https://github.com/jrudolph/perf-map-agent', perf_map_agent_path)
+        sh.cmake('.', _cwd=perf_map_agent_path)
+        sh.make(_cwd=perf_map_agent_path)
+
+    if not os.path.exists(flamegraph_path):
+        sh.git('clone', 'https://github.com/brendangregg/FlameGraph', flamegraph_path)
+
+
+@fab.parallel
+def ensure_stopped_perf_agent():
+    logger.info("Ensure there are no perf agent running")
+
+    def try_kill(process_line):
+        try:
+            sh.sudo.pkill('-f', '-9', process_line)
+        except (sh.ErrorReturnCode, sh.SignalException):
+            pass
+
+    for p in ['perf.script', 'perf.record', 'perf-java-flames']:
+        try_kill(p)
+
+
+@fab.parallel
+def stop_perf_agent():
+    logger.info("Stopping Flamegraph perf agent")
+    perf_record_pid = common_module.find_process_pid("[^/]perf record -F", child_process=True)
+    sh.sudo.kill(perf_record_pid)
+
+    logger.info("Waiting 10 seconds to for the flamegraph generation")
+    time.sleep(10)
+    flamegraph_directory = get_flamegraph_directory()
+    fab.run('sudo chmod o+r {}'.format(os.path.join(flamegraph_directory, '*')))
+
+
+@fab.parallel
+def start_perf_agent(rev_num):
+    logger.info("Starting Flamegraph perf agent")
+    perf_map_agent_path, flamegraph_path = get_flamegraph_paths()
+    java_home = os.path.expanduser(common_module.config['java_home'])
+    cassandra_pid = common_module.find_process_pid("java.*Cassandra")
+    perf_bin = os.path.join(os.path.expanduser('~/fab/perf-map-agent'), 'bin/perf-java-flames')
+    flamegraph_directory = get_flamegraph_directory()
+
+    env_vars = {
+        'JAVA_HOME': java_home,
+        'FLAMEGRAPH_DIR': flamegraph_path,
+        'PERF_RECORD_SECONDS': PERF_RECORDING_DURATION,
+        'PERF_JAVA_TMP': flamegraph_directory,
+        'PERF_DATA_FILE': os.path.join(flamegraph_directory, 'perf_revision_{}.data'.format(rev_num + 1)),
+        'PERF_FLAME_OUTPUT': os.path.join(flamegraph_directory, 'flamegraph_revision_{}.svg'.format(rev_num + 1))
+    }
+
+    common_module.runbg("{perf_bin} {pid}".format(perf_bin=perf_bin, pid=cassandra_pid), env_vars)


### PR DESCRIPTION
Here's the PR so we can begin to review. 

# Setup

1. Install system dependencies

  ```
  sudo apt-get install cmake dtach linux-tools-`uname -r`
  ```

2. Ensure your kernel has performance profling support:

  ```
  $ sudo perf record -F 99 -g -p <a_running_process_pid> -- sleep 10
  [ perf record: Woken up 1 times to write data ]
  [ perf record: Captured and wrote 0.098 MB perf.data (~4278 samples) ]
  ```

3. Add NOPASSWD sudo configuration for the cstar user:

  ``` 
  echo "cstar ALL = (root) NOPASSWD: ALL" | sudo tee /etc/sudoers.d/perf
  ```

4. Enable flamegraph feature in your cluster configuration:

  ```
   "flamegraph": true,
   "flamegraph_directory": "/mnt/data/cstar_perf/flamegraph"
  ```
  The flamegraph working directory default to /tmp/flamegraph if not specified. 

5. Migrate the cstar_perf DB using the following script. (ENSURE you have a backup before)

  ```
  # Execute with CQL, DONT FORGET TO SET '[csv] field_size_limit=1000000000' in ~/.cassandra/cqlshrc
  frontend/cstar_perf/frontend/migrations/0002.cql
  ```

When enabled, you should see a new flamegraph artifact available in the ViewTest page.
