### PR TITLE
server.conf allows specifying cassandra username/password and keyspace to be used

### DIFF
--- a/frontend/cstar_perf/frontend/lib/util.py
+++ b/frontend/cstar_perf/frontend/lib/util.py
@@ -113,3 +113,10 @@ def cd(newdir):
         yield
     finally:
         os.chdir(prevdir)
+
+
+def auth_provider_if_configured(config):
+    if config.has_option('server', 'cassandra_user') and config.has_option('server', 'cassandra_password'):
+        from cassandra.auth import PlainTextAuthProvider
+        return PlainTextAuthProvider(username=config.get('server', 'cassandra_user'), password=config.get('server', 'cassandra_password'))
+    return None

--- a/frontend/cstar_perf/frontend/server/util.py
+++ b/frontend/cstar_perf/frontend/server/util.py
@@ -54,5 +54,5 @@ def csrf_protect_app(app):
             session['_csrf_token'] = random_token()
         return session['_csrf_token']
 
-    app.jinja_env.globals['csrf_token'] = generate_csrf_token 
+    app.jinja_env.globals['csrf_token'] = generate_csrf_token
 


### PR DESCRIPTION
This allows specifying username / password in case C* is configured with password authentication in `server.conf`. It also allows to use a specific keyspace. In our case, we had `cassandra_hosts` point to a cluster with enabled password authentication.
````
[server]
cassandra_hosts=10.200.189.13,10.200.189.130,10.200.189.133
cassandra_user=<user>
cassandra_password=<password>
cassandra_keyspace=<keyspace>
```