### PR TITLE
Return false in flamegraph.is_enabled in case the common_module is None

### DIFF
--- a/tool/cstar_perf/tool/fab_flamegraph.py
+++ b/tool/cstar_perf/tool/fab_flamegraph.py
@@ -23,6 +23,8 @@ def set_common_module(module):
 
 
 def is_enabled(revision_config=None):
+    if not common_module:
+        return False
     is_compatible = True
     is_enabled = common_module.config.get('flamegraph', False)
     if revision_config:


### PR DESCRIPTION
`is_enabled()` is accessed in https://github.com/datastax/cstar_perf/blob/master/tool/cstar_perf/tool/fab_common.py#L442-442 and `common_module` wasn't initialized yet. Maybe an alternate fix might be to properly call https://github.com/datastax/cstar_perf/blob/master/tool/cstar_perf/tool/fab_flamegraph.py#L20-20 before it is used in https://github.com/datastax/cstar_perf/blob/master/tool/cstar_perf/tool/fab_common.py#L442-442 ?