### PR TITLE
Use div id when hiding dse.yaml div container

### DIFF
--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -93,6 +93,9 @@ var addRevisionDiv = function(animate){
     update_cluster_selections();
     update_cluster_options();
 
+    // initially hide the dse yaml settings
+    $("#" + revision_id + "-dse_yaml_div").hide();
+
     //Remove revision handler:
     $("#remove-"+revision_id).click(function() {
         $("div#"+revision_id).slideUp(function() {
@@ -488,9 +491,6 @@ var update_cluster_options = function(operation_id, operation_defaults, callback
 }
 
 var update_cluster_selections = function(callback) {
-    // initiall hide the dse yaml settings
-    $(".dse-yaml-settings-div").hide();
-
     var cluster = $('#cluster').val();
     $.get('/api/clusters/'+cluster, function(data) {
 


### PR DESCRIPTION
Selecting `dse` as the product on the first revision would show the `dse.yaml` div container for that revision. Now when you add a new revision, the `dse.yaml` div container for the previous revision would be hidden, because we don't hide by the div container's id, but just by its css class.
This PR fixes it and correctly uses the `dse.yaml` div container id