### PR TITLE
Allow installing DSE from a source branch

### DIFF
--- a/tool/cstar_perf/tool/fab_deploy.py
+++ b/tool/cstar_perf/tool/fab_deploy.py
@@ -19,6 +19,7 @@ import json
 import re
 import operator
 
+
 fab.env.use_ssh_config = True
 fab.env.connection_attempts = 10
 
@@ -200,7 +201,10 @@ def get_client_jvms():
     jvms = [jvm for jvm in output.split(' ') if jvm]
     return jvms
 
-def enable_dse(dse_repo_url, dse_repo_username=None, dse_repo_password=None):
+
+def enable_dse(dse_repo_url, dse_repo_username=None, dse_repo_password=None, dse_source_build_artifactory_url=None,
+               dse_source_build_artifactory_username=None, dse_source_build_artifactory_password=None,
+               dse_source_build_oauth_token=None):
     """Enable DSE"""
 
     enable_dse_script = """
@@ -209,6 +213,11 @@ def enable_dse(dse_repo_url, dse_repo_username=None, dse_repo_password=None):
     config['dse_url'] = '{url}'
     username = '{username}'
     pw = '{pw}'
+    dse_source_build_artifactory_url = '{dse_source_build_artifactory_url}'
+    dse_source_build_artifactory_username = '{dse_source_build_artifactory_username}'
+    dse_source_build_artifactory_password = '{dse_source_build_artifactory_password}'
+    dse_source_build_oauth_token = '{dse_source_build_oauth_token}'
+
     if username:
         config['dse_username'] = username
     elif 'dse_username' in config:
@@ -219,9 +228,33 @@ def enable_dse(dse_repo_url, dse_repo_username=None, dse_repo_password=None):
     elif 'dse_password' in config:
         del config['dse_password']
 
+    if dse_source_build_artifactory_url:
+        config['dse_source_build_artifactory_url'] = dse_source_build_artifactory_url
+    elif 'dse_source_build_artifactory_url' in config:
+        del config['dse_source_build_artifactory_url']
+
+    if dse_source_build_artifactory_username:
+        config['dse_source_build_artifactory_username'] = dse_source_build_artifactory_username
+    elif 'dse_source_build_artifactory_username' in config:
+        del config['dse_source_build_artifactory_username']
+
+    if dse_source_build_artifactory_password:
+        config['dse_source_build_artifactory_password'] = dse_source_build_artifactory_password
+    elif 'dse_source_build_artifactory_password' in config:
+        del config['dse_source_build_artifactory_password']
+
+    if dse_source_build_oauth_token:
+        config['dse_source_build_oauth_token'] = dse_source_build_oauth_token
+    elif 'dse_source_build_oauth_token' in config:
+        del config['dse_source_build_oauth_token']
+
     with open(cluster_config_file, 'w') as f:
         f.write(json.dumps(config, sort_keys=True, indent=4, separators=(',', ': ')))
-    """.format(url=dse_repo_url, username=dse_repo_username, pw=dse_repo_password)
+    """.format(url=dse_repo_url, username=dse_repo_username, pw=dse_repo_password,
+               dse_source_build_artifactory_url=dse_source_build_artifactory_url,
+               dse_source_build_artifactory_username=dse_source_build_artifactory_username,
+               dse_source_build_artifactory_password=dse_source_build_artifactory_password,
+               dse_source_build_oauth_token=dse_source_build_oauth_token)
     print run_python_script(enable_dse_script)
 
 def add_product_to_cluster(cluster_name, product):

--- a/tool/cstar_perf/tool/fab_dse.py
+++ b/tool/cstar_perf/tool/fab_dse.py
@@ -1,12 +1,13 @@
 import os
-import requests
-import yaml
 import re
 from urlparse import urljoin
+
+import yaml
 from fabric import api as fab
 from fabric.state import env
 
 from util import download_file, download_file_contents, digest_file
+
 
 # I don't like global ...
 global config

--- a/tool/cstar_perf/tool/fab_dse.py
+++ b/tool/cstar_perf/tool/fab_dse.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 from urlparse import urljoin
@@ -7,6 +8,10 @@ from fabric import api as fab
 from fabric.state import env
 
 from util import download_file, download_file_contents, digest_file
+
+logging.basicConfig()
+logger = logging.getLogger('dse')
+logger.setLevel(logging.INFO)
 
 
 # I don't like global ...
@@ -42,7 +47,7 @@ def setup(cfg):
     download_tarball = True
 
     revision = config['revision']
-    print('Using DSE revision: {rev}'.format(rev=revision))
+    logger.info('Using DSE revision: {rev}'.format(rev=revision))
     if revision.startswith('bdp/'):
         download_tarball = False
         oauth_token = config.get('dse_source_build_oauth_token', None)
@@ -82,10 +87,10 @@ def download_binaries():
     assert(len(correct_sha) == 64, 'Failed to download sha file: {}'.format(correct_sha))
 
     if os.path.exists(filename):
-        print("Already in cache: {}".format(filename))
+        logger.info("Already in cache: {}".format(filename))
         real_sha = digest_file(filename)
         if real_sha != correct_sha:
-            print("Invalid SHA for '{}'. It will be removed".format(filename))
+            logger.info("Invalid SHA for '{}'. It will be removed".format(filename))
             os.remove(filename)
         else:
             return
@@ -220,7 +225,7 @@ def _checkout_dse_branch_and_build_tarball_from_source(branch):
                           capture=True)
     dse_tarball = os.path.basename(path_name)
 
-    print('Created tarball from source: {tarball}'.format(tarball=dse_tarball))
+    logger.info('Created tarball from source: {tarball}'.format(tarball=dse_tarball))
     fab.local('cp {bdp_git}/build/{tarball} {dse_cache}'.format(bdp_git=bdp_git, dse_cache=dse_cache, tarball=dse_tarball))
 
     # remove the maven & gradle settings after the tarball got created

--- a/tool/cstar_perf/tool/fab_dse.py
+++ b/tool/cstar_perf/tool/fab_dse.py
@@ -1,8 +1,10 @@
 import os
+import requests
+import yaml
 import re
 from urlparse import urljoin
-import yaml
 from fabric import api as fab
+from fabric.state import env
 
 from util import download_file, download_file_contents, digest_file
 
@@ -19,6 +21,7 @@ DSE_NODE_TYPE_TO_STARTUP_PARAM = {'spark': '-k',
 
 name = 'dse'
 
+
 def setup(cfg):
     "Local setup for dse"
 
@@ -26,10 +29,8 @@ def setup(cfg):
 
     config = cfg
 
-    if 'dse_url' not in  config:
+    if 'dse_url' not in config:
         raise ValueError("dse_url is missing from cluster_config.json.")
-
-    dse_tarball = "dse-{}-bin.tar.gz".format(config['revision'])
 
     # Create dse_cache_dir
     dse_builds = os.path.expanduser("~/fab/dse_builds")
@@ -37,8 +38,31 @@ def setup(cfg):
     if not os.path.exists(dse_cache):
         os.makedirs(dse_cache)
 
-    if config["product"] == 'dse':
+    download_tarball = True
+
+    revision = config['revision']
+    print('Using DSE revision: {rev}'.format(rev=revision))
+    if revision.startswith('bdp/'):
+        download_tarball = False
+        oauth_token = config.get('dse_source_build_oauth_token', None)
+        if not config.get('dse_source_build_oauth_token', None):
+            raise ValueError('dse_source_build_oauth_token for checking out a DSE branch is missing from cluster_config.json.')
+
+        if not config.get('dse_source_build_artifactory_username', None):
+            raise ValueError('dse_source_build_artifactory_username for building a DSE branch is missing from cluster_config.json.')
+
+        if not config.get('dse_source_build_artifactory_password', None):
+            raise ValueError('dse_source_build_artifactory_password for building a DSE branch is missing from cluster_config.json.')
+
+        if not config.get('dse_source_build_artifactory_url', None):
+            raise ValueError('dse_source_build_artifactory_url for building a DSE branch is missing from cluster_config.json.')
+
+        _checkout_dse_branch_and_build_tarball_from_source(branch=revision[4:])
+
+    if download_tarball:
+        dse_tarball = "dse-{revision}-bin.tar.gz".format(revision=revision)
         download_binaries()
+
 
 def download_binaries():
     "Parse config and download dse binaries (local)"
@@ -73,6 +97,7 @@ def download_binaries():
         raise AssertionError(
             ('SHA of DSE tarball was not verified. should have been: '
              '{correct_sha} but saw {real_sha}').format(correct_sha=correct_sha, real_sha=real_sha))
+
 
 def get_dse_path():
     return "~/fab/dse"
@@ -158,3 +183,88 @@ def get_dse_config_options(config):
 
     """
     return _get_config_options(config=config, config_class='com.datastax.bdp.config.Config')
+
+def _checkout_dse_branch_and_build_tarball_from_source(branch):
+    global dse_cache, dse_tarball, config
+
+    java_home = config['java_home']
+    oauth_token = config.get('dse_source_build_oauth_token')
+    bdp_git = '~/fab/bdp.git'
+
+    _setup_maven_authentication(config)
+    _setup_gradle_authentication(config)
+
+    fab.local('rm -rf {bdp_git}'.format(bdp_git=bdp_git))
+    fab.local('mkdir -p {bdp_git}'.format(bdp_git=bdp_git))
+    fab.local('git clone -b {branch} --single-branch https://{oauth_token}@github.com/riptano/bdp.git {bdp_git}'.format(
+        branch=branch, oauth_token=oauth_token, bdp_git=bdp_git))
+
+    # build the tarball from source
+    env.ok_ret_codes = [0, 1]
+    gradle_file_exists = fab.local('[ -e  {bdp_git}/build.gradle ]'.format(bdp_git=bdp_git))
+    env.ok_ret_codes = [0]
+
+    if gradle_file_exists.return_code == 0:
+        # run the gradle build
+        fab.local('export TERM=dumb; cd {bdp_git}; ./gradlew distTar -PbuildType={branch}'.format(bdp_git=bdp_git, branch=branch))
+    else:
+        # run the ant build
+        fab.local(
+            'cd {bdp_git}; JAVA_HOME={java_home} ANT_HOME=$HOME/fab/ant/ $HOME/fab/ant/bin/ant -Dversion={branch} -Dcompile.native=true release'.format(
+                branch=branch, java_home=java_home, bdp_git=bdp_git))
+
+    # we need to expand the tarball name because the name will look as following: dse-{version}-{branch}-bin.tar.gz
+    # example: dse-4.8.3-4.8-dev-bin.tar.gz
+    path_name = fab.local('readlink -e {bdp_git}/build/dse-*{branch}-bin.tar.gz'.format(bdp_git=bdp_git, branch=branch),
+                          capture=True)
+    dse_tarball = os.path.basename(path_name)
+
+    print('Created tarball from source: {tarball}'.format(tarball=dse_tarball))
+    fab.local('cp {bdp_git}/build/{tarball} {dse_cache}'.format(bdp_git=bdp_git, dse_cache=dse_cache, tarball=dse_tarball))
+
+    # remove the maven & gradle settings after the tarball got created
+    fab.local('rm -rf ~/.m2/settings.xml')
+    fab.local('rm -rf ~/.gradle')
+
+
+def _setup_maven_authentication(config):
+    dse_source_build_artifactory_username = config.get('dse_source_build_artifactory_username')
+    dse_source_build_artifactory_password = config.get('dse_source_build_artifactory_password')
+    dse_source_build_artifactory_url = config.get('dse_source_build_artifactory_url')
+
+    maven_settings = "<settings><mirrors><mirror><id>artifactory</id><name>DataStax Maven repository</name>" \
+                     "<url>{url}</url>" \
+                     "<mirrorOf>central,java.net2,xerial,datanucleus,apache,datastax-public-snapshot,datastax-public-release,datastax-deps,datastax-release,datastax-snapshot</mirrorOf>" \
+                     "</mirror></mirrors><servers><server><id>artifactory</id><username>{username}</username>" \
+                     "<password>{password}</password></server></servers></settings>" \
+        .format(username=dse_source_build_artifactory_username, password=dse_source_build_artifactory_password,
+                url=dse_source_build_artifactory_url)
+
+    fab.local('rm -rf ~/.m2/settings.xml')
+    fab.local('mkdir -p ~/.m2')
+    fab.local('echo "{maven_settings}" > ~/.m2/settings.xml'.format(maven_settings=maven_settings))
+
+
+def _setup_gradle_authentication(config):
+    dse_source_build_artifactory_username = config.get('dse_source_build_artifactory_username')
+    dse_source_build_artifactory_password = config.get('dse_source_build_artifactory_password')
+    dse_source_build_artifactory_url = config.get('dse_source_build_artifactory_url')
+
+    gradle_settings = """
+allprojects {{
+    repositories {{
+        maven {{
+            url = "\\"{url}\\""
+            credentials {{
+                username '{username}'
+                password '{password}'
+            }}
+        }}
+    }}
+}}
+    """.format(username=dse_source_build_artifactory_username, password=dse_source_build_artifactory_password,
+               url=dse_source_build_artifactory_url)
+
+    fab.local('rm -rf ~/.gradle')
+    fab.local('mkdir -p ~/.gradle/init.d')
+    fab.local('echo "{gradle_settings}" > ~/.gradle/init.d/nexus.gradle'.format(gradle_settings=gradle_settings))


### PR DESCRIPTION
This PR allows us to run a perf test where we can install DSE from a branch. 

* All sensitive information (artifactory username / password / url and an oauth token for checking out the DSE branch) will be provided through `cluster_config.json`.
* The user enters `bdp/DSP-1234` in the revision field of the UI. Due to the prefix `bdp/` in the revision field, we know that the user wants to build from a branch. 
* We extract the branch name `DSP-1234` from that revision field and then use it to checkout this particular branch.
* Depending on the DSE version, we either need to run a legacy ant build or a gradle build.  
* The source build will create a tarball from the specified branch and will be running on the node that is hosting `cstar_perf.tool`. Once the tarball got created, it will be uploaded as specified in https://github.com/datastax/cstar_perf/blob/2444911d9ec5e2d0bd59466ef83f1ebf175c30a9/tool/cstar_perf/tool/fab_dse.py#L114-L119.

@EnigmaCurry / @aboudreault can you guys review please?
