### PR TITLE
Remove previous DSE build folder for a specific version in case it already exists

### DIFF
--- a/tool/cstar_perf/tool/fab_dse.py
+++ b/tool/cstar_perf/tool/fab_dse.py
@@ -124,6 +124,8 @@ def get_bin_path():
 def bootstrap(config):
     filename = os.path.join(dse_cache, dse_tarball)
     dest = os.path.join(dse_builds, dse_tarball)
+    # remove build folder if it exists
+    fab.run('rm -rf {}'.format(os.path.join(dse_builds, dse_tarball.replace('-bin.tar.gz', ''))))
 
     # Upload the binaries
     fab.run('mkdir -p {dse_builds}'.format(dse_builds=dse_builds))


### PR DESCRIPTION
The problem is that `~/fab/dse_builds/dse-{revision}` is never cleaned up and so if a a build of the same revision is triggered (but the revision contains updated files), we end up potentially with multiple cassandra jar files in `~/fab/dse_builds/dse-{revision}/resources/cassandra/lib`. The easiest way is to just remove `~/fab/dse_builds/dse-{revision}` before the run, since a couple of codelines later, the tarball will be extracted anyway

@aboudreault can you review please?