### PR TITLE
SSH onto node before executing cqlsh commands

### DIFF
--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -240,17 +240,16 @@ def bash(script, nodes=None, user=None):
         user = common.fab.env.user
     with common.fab.settings(user=user, hosts=nodes):
         return execute(common.bash, script)
-        
+
+
 def cqlsh(script, node):
     """Run a cqlsh script on a node"""
     global cqlsh_path
-    cmd = "{cqlsh_path} --no-color {host}".format(cqlsh_path=cqlsh_path, host=node)
-    proc = subprocess.Popen(shlex.split(cmd),
-                            stdout=subprocess.PIPE,
-                            stdin=subprocess.PIPE,
-                            stderr=subprocess.STDOUT)
-    output = proc.communicate(script)
-    return output[0]
+    script = script.replace('\n', ' ')
+    cmd = '{cqlsh_path} --no-color {host} -e "{script}"'.format(cqlsh_path=cqlsh_path, host=node, script=script)
+
+    with common.fab.settings(fab.show('warnings', 'running', 'stdout', 'stderr'), hosts=node):
+        return execute(fab.run, cmd)[node] 
 
 
 def spark_cassandra_stress(script, node):


### PR DESCRIPTION
The problem with the existing approach of how to run `cqlsh` is that `cqlsh` would be executed itself on the **node hosting the cstar_perf backend** and just provide an IP parameter for connecting to nodeX. 
This would cause problems if the C* version installed on the **cstar_perf backend node** would be much older than on the perf test nodes and you might end up running into an error such as the following:
````
"output": [
                "Connection error: ('Unable to connect to any servers', {'10.200.162.76': ProtocolError(\"cql_version '3.2.1' is not supported by remote (w/ native protocol). Supported versions: [u'3.4.0']\",)})", 
                ""
            ], 
            "revision": "5.0.0", 
            "start_date": "2016-01-18T12:08:08.704220", 
            "test": "1_cqlsh", 
            "type": "cqlsh"
```

In my example I was running DSE 4.8.x (C* 2.1) on the **cstar_perf backend* and wanted to do a perf test on the test cluster with DSE 5.0.0 (C* 3.0.x)

I changed the implementation to do the following things:
* SSH onto nodeX
* launch cqlsh on nodeX by doing `cqlsh --no-color nodeX -e "COMMAND1; COMMAND2; ..."`
* return the string result from executing the command (so that code that is using method `cqlsh(script, node)` doesn't have to deal with any changes


@aboudreault & @EnigmaCurry can you guys please review?