### PR TITLE
Use host mount of /dev/shm to avoid chrome crash

### DIFF
--- a/frontend/cstar_perf/frontend/lib/screenshot.py
+++ b/frontend/cstar_perf/frontend/lib/screenshot.py
@@ -56,6 +56,8 @@ def start_selenium_grid(docker_image='selenium/standalone-chrome'):
                              '-d',
                              '-p',
                              '127.0.0.1:4444:4444',
+                             '-v',
+                             '/dev/shm:/dev/shm',
                              '--name',
                              'cstar_perf_selenium',
                              docker_image])


### PR DESCRIPTION
These pages are the reference for this runtime addition:
https://github.com/SeleniumHQ/docker-selenium#running-the-images
https://bugs.chromium.org/p/chromium/issues/detail?id=519952