### PR TITLE
Allow setting cdc directories through cluster_config.json

### DIFF
--- a/tool/cstar_perf/docker/cstar_docker.py
+++ b/tool/cstar_perf/docker/cstar_docker.py
@@ -43,6 +43,7 @@ RUN \
   apt-get update && \
   apt-get -y upgrade && \
   apt-get install -y \
+      sudo \
       build-essential \
       software-properties-common \
       git \
@@ -480,6 +481,8 @@ def __install_cstar_perf_tool(cluster_name, hosts, mount_host_src=False, first_c
         "data_file_directories": ['/data/cstar_perf/data'],
         "commitlog_directory": '/data/cstar_perf/commitlog',
         "saved_caches_directory": '/data/cstar_perf/saved_caches',
+        'cdc_directory': '/data/cstar_perf/cdc',
+        'cdc_overflow_directory': '/data/cstar_perf/cdc_overflow',
         "docker": True
     }
     

--- a/tool/cstar_perf/tool/fab_deploy.py
+++ b/tool/cstar_perf/tool/fab_deploy.py
@@ -46,6 +46,9 @@ def setup_fab_dir(jdk_roots=['/usr/lib/jvm']):
     version_re = re.compile("^(openjdk|java) version \"(.*)\"$", re.MULTILINE)
     # Find available JDKs:
     for root in jdk_roots:
+        # I found that sometimes running the 'find' command without doing an 'ls' on the root dir would not find
+        # any JDK homes when executing inside a Docker container
+        fab.run('ls -la {jdk_root}'.format(jdk_root=root))
         homes = fab.run("find {root} -maxdepth 1 -mindepth 1 -type d".format(root=root), quiet=True).strip().split()
         for home in homes:
             # Find java binary and test that it runs:


### PR DESCRIPTION
This is for [CASSANDRA-8844](https://issues.apache.org/jira/browse/CASSANDRA-8844). We handle the **cdc** directories the same way as we do the **commitlog_directory** (e.g. not allowed to set them through the cstar_perf UI).

In case the **cdc** directories change with newer [CASSANDRA-8844](https://issues.apache.org/jira/browse/CASSANDRA-8844), we can easily reflect it in this PR.