### PR TITLE
Increase connection timeout when using C* python driver

### DIFF
--- a/frontend/cstar_perf/frontend/lib/server.py
+++ b/frontend/cstar_perf/frontend/lib/server.py
@@ -22,7 +22,7 @@ def run_server():
     from cassandra.cluster import Cluster
 
     auth_provider = auth_provider_if_configured(config)
-    cluster = Cluster(contact_points=cassandra_hosts, auth_provider=auth_provider)
+    cluster = Cluster(contact_points=cassandra_hosts, auth_provider=auth_provider, connect_timeout=30)
 
     keyspace = config.get('server', 'cassandra_keyspace') if config.has_option('server', 'cassandra_keyspace') else 'cstar_perf'
     db = Model(cluster=cluster, keyspace=keyspace)

--- a/frontend/cstar_perf/frontend/server/app.py
+++ b/frontend/cstar_perf/frontend/server/app.py
@@ -30,7 +30,7 @@ sockets = Sockets(app)
 cassandra_hosts = [h.strip() for h in app_config.get('server', 'cassandra_hosts').split(",")]
 from cassandra.cluster import Cluster
 auth_provider = auth_provider_if_configured(app_config)
-cluster = Cluster(contact_points=cassandra_hosts, auth_provider=auth_provider)
+cluster = Cluster(contact_points=cassandra_hosts, auth_provider=auth_provider, connect_timeout=30)
 
 keyspace = app_config.get('server', 'cassandra_keyspace') if app_config.has_option('server', 'cassandra_keyspace') else 'cstar_perf'
 db = Model(cluster=cluster, keyspace=keyspace, email_notifications=app_config.has_section('smtp'))

--- a/frontend/cstar_perf/frontend/server/model.py
+++ b/frontend/cstar_perf/frontend/server/model.py
@@ -124,7 +124,7 @@ class Model(object):
         'insert_api_pubkey': "INSERT INTO api_pubkeys (name, user_type, pubkey) VALUES (?, ?, ?);"
     }
 
-    def __init__(self, cluster=Cluster(['127.0.0.1']), keyspace='cstar_perf', email_notifications=False):
+    def __init__(self, cluster=Cluster(['127.0.0.1'], connect_timeout=30), keyspace='cstar_perf', email_notifications=False):
         """Instantiate DB model object for interacting with the C* backend.
 
         cluster - Python driver object for accessing Cassandra


### PR DESCRIPTION
I don't know if it's related to the new C* python driver that got released yesterday (3.3.0), but as of today, I had problems successfully running the cstar_perf UI in a docker container.

I have been seeing that a client would run into a timeout when establishing a connection with C*:

````
WARNING:cassandra.cluster:[control connection] Error connecting to 127.0.0.1:
Traceback (most recent call last):
  File "cassandra/cluster.py", line 2154, in cassandra.cluster.ControlConnection._reconnect_internal (cassandra/cluster.c:37797)
    return self._try_connect(host)
  File "cassandra/cluster.py", line 2176, in cassandra.cluster.ControlConnection._try_connect (cassandra/cluster.c:38315)
    connection = self._cluster.connection_factory(host.address, is_control_connection=True)
  File "cassandra/cluster.py", line 847, in cassandra.cluster.Cluster.connection_factory (cassandra/cluster.c:10142)
    return self.connection_class.factory(address, self.connect_timeout, *args, **kwargs)
  File "cassandra/connection.py", line 330, in cassandra.connection.Connection.factory (cassandra/connection.c:5749)
    raise OperationTimedOut("Timed out creating connection (%s seconds)" % timeout)
OperationTimedOut: errors=Timed out creating connection (5 seconds), last_host=None
```

After increasing the connection_timeout, things started to work as before.

Please note that the default connection_timeout is **5s**