### PR TITLE
Dont pipe stderr in order to show real error

### DIFF
--- a/tool/cstar_perf/docker/cstar_docker.py
+++ b/tool/cstar_perf/docker/cstar_docker.py
@@ -203,7 +203,7 @@ def check_if_build_necessary(exit_if_not_ready=True):
         
 def get_container_data(container):
     inspect_cmd = shlex.split("docker inspect {}".format(container))
-    p = subprocess.Popen(inspect_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = subprocess.Popen(inspect_cmd, stdout=subprocess.PIPE)
     try:
         return json.loads(p.communicate()[0])[0]
     except IndexError:
@@ -355,7 +355,7 @@ def launch(num_nodes, cluster_name='cnode', destroy_existing=False,
         run_cmd = run_cmd + ' ' + docker_image_name
         log.debug(run_cmd)
         p=subprocess.Popen(shlex.split(run_cmd),
-                           stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                           stdout=subprocess.PIPE)
         container_id = p.communicate()[0].strip()
         node_data[node_name] = get_container_data(container_id)
     hosts = OrderedDict()
@@ -521,7 +521,7 @@ def destroy(cluster_regex):
             log.info('Destroying {} containers...'.format(cluster_regex))
         for container in containers:
             destroy_cmd = shlex.split("docker rm -f {}".format(container))
-            subprocess.call(destroy_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            subprocess.call(destroy_cmd, stdout=subprocess.PIPE)
 
 def associate(frontend_name, cluster_names, with_dse=False):
 
@@ -643,7 +643,7 @@ def start(cluster_name):
     cluster = clusters[cluster_name]
     for container in cluster:
         start_cmd = shlex.split("docker start {}".format(container))
-        subprocess.call(start_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.call(start_cmd, stdout=subprocess.PIPE)
     __update_node_ip_addresses(cluster_name)
 
 def stop(cluster_name):
@@ -652,7 +652,7 @@ def stop(cluster_name):
     cluster = clusters[cluster_name]
     for container in cluster:
         stop_cmd = shlex.split("docker stop {}".format(container))
-        subprocess.call(stop_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.call(stop_cmd, stdout=subprocess.PIPE)
 
 def list_clusters():
     """List clusters"""


### PR DESCRIPTION
This will show the real error happening when running cstar_perf inside a docker container

````
$ cstar_docker launch test_cluster 1 -m
INFO:cstar_docker:Launching a 2 node cluster with a separate client node ...
DEBUG:cstar_docker:docker run --ulimit memlock=100000000:100000000 --privileged --label cstar_node=true --label cluster_name=test_cluster --label cluster_type=cluster --label node=0  -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/bin/docker -d -m 2G --name=test_cluster_00  -h test_cluster_00 -v /home/automaton/git/cstar_perf:/home/cstar/git/cstar_perf datastax/cstar_docker
docker: invalid hostname format for --hostname: test_cluster_00.
See 'docker run --help'.
docker: "inspect" requires a minimum of 1 argument.
See 'docker inspect --help'.

Usage:	docker inspect [OPTIONS] CONTAINER|IMAGE [CONTAINER|IMAGE...]

Return low-level information on a container or image
Traceback (most recent call last):
  File "/home/automaton/git/cstar_perf/env/bin/cstar_docker", line 9, in <module>
    load_entry_point('cstar-perf.tool==1.0', 'console_scripts', 'cstar_docker')()
  File "/home/automaton/git/cstar_perf/tool/cstar_perf/docker/cstar_docker.py", line 816, in main
    execute_cmd(args.command, args)
  File "/home/automaton/git/cstar_perf/tool/cstar_perf/docker/cstar_docker.py", line 692, in execute_cmd
    client_double_duty=args.client_double_duty)
  File "/home/automaton/git/cstar_perf/tool/cstar_perf/docker/cstar_docker.py", line 360, in launch
    node_data[node_name] = get_container_data(container_id)
  File "/home/automaton/git/cstar_perf/tool/cstar_perf/docker/cstar_docker.py", line 208, in get_container_data
    return json.loads(p.communicate()[0])[0]
  File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
````

