### PR TITLE
Allow '-' in cluster names

### DIFF
--- a/frontend/cstar_perf/frontend/client/client.py
+++ b/frontend/cstar_perf/frontend/client/client.py
@@ -759,8 +759,8 @@ def create_credentials():
     else:
         while True:
             cluster_name = raw_input('Enter a name for this cluster: ')
-            if not re.match(r'^[a-zA-Z0-9_]+$', cluster_name):
-                print("Cluster name must be of the characters a-z, A-Z, 0-9, and _")
+            if not re.match(r'^[a-zA-Z0-9_-]+$', cluster_name):
+                print("Cluster name must be of the characters a-z, A-Z, 0-9, _ and -")
                 continue
             break
         config.set('cluster', 'name', cluster_name)


### PR DESCRIPTION
This should have gone into #196, but it was merged too fast :) 

The PR will fix

````
$ cstar_docker associate test-frontend test-cluster
[172.17.0.2] Executing task 'get_frontend_credentials'
[172.17.0.2] run: cat ~/credentials.txt
[172.17.0.2] out: New server keys saved to /home/cstar/.cstar_perf/server.conf
[172.17.0.2] out: Server public key: zqGjwm9TqaGSPIZ9fysJ+1zvEk0wYPbvndy3RHBZaAt0EjJykEUT66rb0ha4VsUz
[172.17.0.2] out: Server verify code: YWVjYzQzMGUtMTFmMy0xMWU2LWJjMjQtMDI0MmFjMTEwMDAyfFlwdGhXUU9LZGJ0NWpqY294VDc1K21LZGZ5dkRoeW02d2ZrRllBWCtLWE4yTjlWODc3WU9UMGlvOTNJQ2FGNGg=
[172.17.0.2] out:

[172.17.0.3] Executing task 'generate_client_credentials'
[172.17.0.3] put: /Users/nastra/Development/cstar_perf/env/lib/python2.7/site-packages/pexpect/__init__.py -> /tmp/__init__.py
[172.17.0.3] put: <file obj> -> /tmp/fexpect_AYcQEjAkfE4uWfX2Zz5EZ4
[172.17.0.3] run: python /tmp/fexpect_AYcQEjAkfE4uWfX2Zz5EZ4
[172.17.0.3] out: Config file is : /home/cstar/.cstar_perf/client.conf
[172.17.0.3] out:
[172.17.0.3] out: Enter a name for this cluster: test-cluster
[172.17.0.3] out: test-cluster
[172.17.0.3] out:
[172.17.0.3] out: Cluster name must be of the characters a-z, A-Z, 0-9, and _
````