### PR TITLE
CSTAR-85: Improve JobCancellationTracker / Gracefully handle termination in stress_compare

### DIFF
--- a/frontend/cstar_perf/frontend/client/api_client.py
+++ b/frontend/cstar_perf/frontend/client/api_client.py
@@ -34,7 +34,7 @@ class APIClient(object):
             r = self.session.get(self.endpoint + path, **kwargs)
         if r.status_code == 200:
             return r.json()
-        error = u'Request failed to {} - {} {}'.format(path, r, body).encode("utf-8")
+        error = u'Request failed to {} - {} {}'.format(self.endpoint + path, r, body).encode("utf-8")
         raise RuntimeError(error)
 
     def post(self, path, data=None, **kwargs):

--- a/frontend/cstar_perf/frontend/client/client.py
+++ b/frontend/cstar_perf/frontend/client/client.py
@@ -743,8 +743,8 @@ class JobCancellationTracker(threading.Thread):
         """Kill cstar_perf_stress and cassandra-stress"""
         for proc in psutil.process_iter():
             if proc.name().startswith("cstar_perf_stre"):
-                log.info("Killing cstar_perf_stress - pid:{}".format(proc.pid))
-                proc.kill()
+                log.info("Terminating cstar_perf_stress - pid:{}".format(proc.pid))
+                proc.terminate()
             if proc.name() == "java":
                 if "org.apache.cassandra.stress.Stress" in " ".join(proc.cmdline()):
                     log.info("Killing cassandra-stress - pid:{}".format(proc.pid))

--- a/frontend/cstar_perf/frontend/client/client.py
+++ b/frontend/cstar_perf/frontend/client/client.py
@@ -237,8 +237,12 @@ class JobRunner(object):
                 with open(os.path.join(job_dir, 'failure.json'), 'w') as f:
                     json.dump({"message":message, "stacktrace":stacktrace}, f)
                 break
-
-            self.__job_done(job['test_id'], status=status_to_submit, message=message, stacktrace=stacktrace)
+            job_id = job['test_id']
+            if status_to_submit == 'completed' and JobStatusRetriever.get_job_status(test_id=job_id, api_endpoint_url=urlparse.urlparse(self.ws_endpoint).netloc) == 'cancel_pending':
+                log.info('Job {job_id} was previously pending a cancel - setting job status to cancelled in the db'.format(job_id=job_id))
+                self.__job_done(job_id, status='cancelled')
+            else:
+                self.__job_done(job_id, status=status_to_submit, message=message, stacktrace=stacktrace)
             
     def perform_job(self, job):
         """Perform a job the server gave us, stream output and artifacts to the given websocket."""
@@ -611,7 +615,13 @@ class JobRunner(object):
                 # again:
                 self.stream_artifacts(job_id)
                 if self.__ws_client.in_sync():
-                    self.__job_done(job_id, status='completed')
+                    # in case the job is in cancel_pending status and artifacts were stored, we need to set the job status to
+                    # 'cancelled' in the db
+                    if JobStatusRetriever.get_job_status(test_id=job_id, api_endpoint_url=urlparse.urlparse(self.ws_endpoint).netloc) == 'cancel_pending':
+                        log.info('Job {job_id} was previously pending a cancel - setting job status to cancelled in the db'.format(job_id=job_id))
+                        self.__job_done(job_id, status='cancelled')
+                    else:
+                        self.__job_done(job_id, status='completed')
                     with open(os.path.join(job_dir, '0.job_status'), 'w') as f:
                         f.write('server_complete')                    
             else:
@@ -713,6 +723,20 @@ class UpdateServerProgressMessageHandler(RegexMatchingEventHandler):
         api_client.post('/tests/progress/id/{}'.format(self._job['test_id']), data=json.dumps({'progress_msg': msg}))
 
 
+class JobStatusRetriever(object):
+
+    @staticmethod
+    def get_job_status(test_id, api_endpoint_url):
+        api_client = APIClient(api_endpoint_url)
+        try:
+            status = api_client.get('/tests/status/id/' + test_id)
+        except Exception as e:
+            log.error(e.message)
+            status = None
+        log.debug('JobStatusRetriever -- status of test_id {test_id} is: {s}'.format(s=status, test_id=test_id))
+        return status.get('status') if status else None
+
+
 class JobCancellationTracker(threading.Thread):
     """Thread to poll test status changes on the server and kill jobs if requested"""
     def __init__(self, server, test_id, check_interval=60):
@@ -732,7 +756,7 @@ class JobCancellationTracker(threading.Thread):
             except Exception as e:
                 log.error(e.message)
                 status = None
-            log.debug('JobCancellationTracker -- status is: {s}'.format(s=status))
+            log.debug('JobCancellationTracker -- status of test_id {test_id} is: {s}'.format(s=status, test_id=self.test_id))
             if status and status.get('status', None) in ('cancelled', 'cancel_pending'):
                 self.kill_jobs()
 

--- a/frontend/cstar_perf/frontend/server/controllers.py
+++ b/frontend/cstar_perf/frontend/server/controllers.py
@@ -83,13 +83,13 @@ def user_in_role(role, user=None):
 
 def requires_auth(role):
     """Ensures the current user has the appropriate authorization before
-    running the wrapped function"""
+    running the wrapped function. In case the role is set, it will also check if the given user has the required role."""
     def decorator(function):
         @functools.wraps(function)
         def wrapper(*args, **kw):
             # Do the check:
             if user_is_authenticated():
-                if user_in_role(role):
+                if not role or user_in_role(role):
                     return function(*args, **kw)
             return make_response(render_template('access_denied.jinja2.html'), 401)
         return wrapper
@@ -555,7 +555,7 @@ def get_series_graph_png_cached_invalidating( series, age, operation, metric):
                     mimetype='application/png')
 
 @app.route('/api/tests/status/id/<test_id>')
-@requires_auth('user')
+@requires_auth(role=None)  # we don't need to check if the user has a role
 def get_test_status(test_id):
     """Retrieve the status for a test"""
     try:
@@ -580,7 +580,7 @@ def get_clusters_by_name(cluster_name):
 
 
 @app.route('/api/tests/progress/id/<test_id>', methods=['POST'])
-@requires_auth('user')
+@requires_auth(role=None)  # we don't need to check if the user has a role
 def set_progress_message_on_test(test_id):
     msg = request.get_json()['progress_msg']
     db.update_test_progress_msg(test_id, msg)

--- a/frontend/cstar_perf/frontend/static/js/view_test.js
+++ b/frontend/cstar_perf/frontend/static/js/view_test.js
@@ -42,7 +42,7 @@ $(document).ready(function() {
             });
         });
         field.parent().append(btn);
-    } else if (field.text() === 'failed') {
+    } else if (field.text() === 'failed' || field.text() === 'cancelled') {
         field.addClass('error')
     } else if (field.text() === 'completed') {
         field.addClass('success')

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -95,8 +95,6 @@ class GracefulTerminationHandler(object):
     def __exit__(self, type, value, tb):
         logger.info('GracefulTerminationHandler -- __exit__')
         self.release()
-        logger.info('GracefulTerminationHandler -- exiting with code 1')
-        sys.exit(1)
 
     def release(self):
         if self.released:

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -25,6 +25,8 @@ import shlex
 import shutil
 import sh
 import distutils.util
+import signal
+
 
 logging.basicConfig()
 logger = logging.getLogger('stress_compare')
@@ -65,6 +67,44 @@ def validate_operations_list(operations):
             assert op.has_key('node'), "spark_cassandra_stress missing node to run on"
         elif op['type'] == 'ctool':
             assert op.has_key('command'), "ctool is missing parameters"
+
+
+class GracefulTerminationHandler(object):
+    """
+    Adapted from https://gist.github.com/nonZero/2907502.
+
+    Will detect a graceful termination and try to grab system.logs / stats files / flamegraphs.
+    """
+
+    def __init__(self, sig=signal.SIGTERM):
+        self.sig = sig
+
+    def __enter__(self):
+        logger.info('GracefulTerminationHandler -- __enter__')
+        self.terminated = False
+        self.released = False
+        self.original_handler = signal.getsignal(self.sig)
+
+        def handler(signum, frame):
+            self.release()
+            self.terminated = True
+
+        signal.signal(self.sig, handler)
+        return self
+
+    def __exit__(self, type, value, tb):
+        logger.info('GracefulTerminationHandler -- __exit__')
+        self.release()
+        logger.info('GracefulTerminationHandler -- exiting with code 1')
+        sys.exit(1)
+
+    def release(self):
+        if self.released:
+            return False
+
+        signal.signal(self.sig, self.original_handler)
+        self.released = True
+        return True
 
 
 def stress_compare(revisions,
@@ -136,207 +176,208 @@ def stress_compare(revisions,
     stress_revisions = set([operation['stress_revision'] for operation in operations if 'stress_revision' in operation])
     stress_shas = setup_stress(stress_revisions)
 
-    for rev_num, revision_config in enumerate(revisions):
-        config = copy.copy(pristine_config)
-        config.update(revision_config)
-        revision = revision_config['revision']
-        config['log'] = log
-        config['title'] = title
-        config['subtitle'] = subtitle
-        product = dse if config.get('product') == 'dse' else cstar
+    with GracefulTerminationHandler() as handler:
+        for rev_num, revision_config in enumerate(revisions):
+            config = copy.copy(pristine_config)
+            config.update(revision_config)
+            revision = revision_config['revision']
+            config['log'] = log
+            config['title'] = title
+            config['subtitle'] = subtitle
+            product = dse if config.get('product') == 'dse' else cstar
 
-        # leave_data setting can be set in the revision
-        # configuration, or manually in the call to this function.
-        # Either is fine, but they shouldn't conflict. If they do,
-        # ValueError is raised.
-        if leave_data == True and revision_config.get('leave_data', None) == False:
-            raise ValueError('setting for leave_data conflicts in job config and stress_compare() call')
-        else:
-            leave_data = bool(distutils.util.strtobool(str(revision_config.get('leave_data', leave_data))))
+            # leave_data setting can be set in the revision
+            # configuration, or manually in the call to this function.
+            # Either is fine, but they shouldn't conflict. If they do,
+            # ValueError is raised.
+            if leave_data == True and revision_config.get('leave_data', None) == False:
+                raise ValueError('setting for leave_data conflicts in job config and stress_compare() call')
+            else:
+                leave_data = bool(distutils.util.strtobool(str(revision_config.get('leave_data', leave_data))))
 
-        logger.info("Bringing up {revision} cluster...".format(revision=revision))
+            logger.info("Bringing up {revision} cluster...".format(revision=revision))
 
-        # Drop the page cache between each revision, especially
-        # important when leave_data=True :
-        if not keep_page_cache:
-            drop_page_cache()
+            # Drop the page cache between each revision, especially
+            # important when leave_data=True :
+            if not keep_page_cache:
+                drop_page_cache()
 
-        # Only fetch from git on the first run:
-        git_fetch = True if rev_num == 0 else False
-        revision_config['git_id'] = git_id = bootstrap(config,
-                                                       destroy=initial_destroy,
-                                                       leave_data=leave_data,
-                                                       git_fetch=git_fetch)
+            # Only fetch from git on the first run:
+            git_fetch = True if rev_num == 0 else False
+            revision_config['git_id'] = git_id = bootstrap(config,
+                                                           destroy=initial_destroy,
+                                                           leave_data=leave_data,
+                                                           git_fetch=git_fetch)
 
-        if flamegraph.is_enabled(revision_config):
-            execute(flamegraph.ensure_stopped_perf_agent)
-            execute(flamegraph.start_perf_agent, rev_num)
-
-        if capture_fincore:
-            start_fincore_capture(interval=10)
-
-        last_stress_operation_id = 'None'
-        for operation_i, operation in enumerate(operations, 1):
-            try:
-                start = datetime.datetime.now()
-                stats = {
-                    "id": str(uuid.uuid1()),
-                    "type": operation['type'],
-                    "revision": revision,
-                    "git_id": git_id,
-                    "start_date": start.isoformat(),
-                    "label": revision_config.get('label', revision_config['revision']),
-                    "test": '{operation_i}_{operation}'.format(
-                        operation_i=operation_i,
-                        operation=operation['type'])
-                }
-
-                if operation['type'] == 'stress':
-                    last_stress_operation_id = stats['id']
-                    # Default to all the nodes of the cluster if no
-                    # nodes were specified in the command:
-                    if operation.has_key('nodes'):
-                        cmd = "{command} -node {hosts}".format(
-                            command=operation['command'],
-                            hosts=",".join(operation['nodes']))
-                    elif '-node' in operation['command']:
-                        cmd = operation['command']
-                    else:
-                        cmd = "{command} -node {hosts}".format(
-                            command=operation['command'],
-                            hosts=",".join([n for n in fab_config['hosts']]))
-                    stats['command'] = cmd
-                    stats['intervals'] = []
-                    stats['test'] = '{operation_i}_{operation}'.format(
-                        operation_i=operation_i, operation=cmd.strip().split(' ')[0]).replace(" ", "_")
-                    logger.info('Running stress operation : {cmd}  ...'.format(cmd=cmd))
-                    # Run stress:
-                    # (stress takes the stats as a parameter, and adds
-                    #  more as it runs):
-                    stress_sha = stress_shas[operation.get('stress_revision', 'default')]
-                    stats = stress(cmd, revision, stress_sha, stats=stats)
-                    # Wait for all compactions to finish (unless disabled):
-                    if operation.get('wait_for_compaction', True):
-                        compaction_throughput = revision_config.get("compaction_throughput_mb_per_sec", 16)
-                        wait_for_compaction(compaction_throughput=compaction_throughput)
-
-                elif operation['type'] == 'nodetool':
-                    if 'nodes' not in operation:
-                        operation['nodes'] = 'all'
-                    if operation['nodes'] in ['all','ALL']:
-                        nodes = [n for n in fab_config['hosts']]
-                    else:
-                        nodes = operation['nodes']
-
-                    set_nodetool_path(os.path.join(product.get_bin_path(), 'nodetool'))
-                    logger.info("Running nodetool on {nodes} with command: {command}".format(nodes=operation['nodes'], command=operation['command']))
-                    stats['command'] = operation['command']
-                    output = nodetool_multi(nodes, operation['command'])
-                    stats['output'] = output
-                    logger.info("Nodetool command finished on all nodes")
-
-                elif operation['type'] == 'cqlsh':
-                    logger.info("Running cqlsh commands on {node}".format(node=operation['node']))
-                    set_cqlsh_path(os.path.join(product.get_bin_path(), 'cqlsh'))
-                    output = cqlsh(operation['script'], operation['node'])
-                    stats['output'] = output.split("\n")
-                    stats['command'] = operation['script']
-                    logger.info("Cqlsh commands finished")
-
-                elif operation['type'] == 'bash':
-                    nodes = operation.get('nodes', [n for n in fab_config['hosts']])
-                    logger.info("Running bash commands on: {nodes}".format(nodes=nodes))
-                    stats['output'] = bash(operation['script'], nodes)
-                    stats['command'] = operation['script']
-                    logger.info("Bash commands finished")
-
-                elif operation['type'] == 'spark_cassandra_stress':
-                    node = operation['node']
-                    logger.info("Running spark_cassandra_stress on {node}".format(node=node))
-                    output = spark_cassandra_stress(operation['script'], node)
-                    stats['output'] = output
-                    logger.info("spark_cassandra_stress finished")
-
-                elif operation['type'] == 'ctool':
-                    logger.info("Running ctool with parameters: {command}".format(command=operation['command']))
-                    ctool = Ctool(operation['command'], common.config)
-                    output = execute(ctool.run)
-                    stats['output'] = output
-                    logger.info("ctool finished")
-
-                elif operation['type'] == 'dsetool':
-                    if 'nodes' not in operation:
-                        operation['nodes'] = 'all'
-                    if operation['nodes'] in ['all','ALL']:
-                        nodes = [n for n in fab_config['hosts']]
-                    else:
-                        nodes = operation['nodes']
-
-                    dsetool_options = operation['script']
-                    logger.info("Running dsetool {command} on {nodes}".format(nodes=operation['nodes'], command=dsetool_options))
-                    stats['command'] = dsetool_options
-                    output = dsetool_cmd(nodes=nodes, options=dsetool_options)
-                    stats['output'] = output
-                    logger.info("dsetool command finished on all nodes")
-
-                elif operation['type'] == 'dse':
-                    logger.info("Running dse command on {node}".format(node=operation['node']))
-                    output = dse_cmd(node=operation['node'], options=operation['script'])
-                    stats['output'] = output.split("\n")
-                    stats['command'] = operation['script']
-                    logger.info("dse commands finished")
-
-                end = datetime.datetime.now()
-                stats['end_date'] = end.isoformat()
-                stats['op_duration'] = str(end - start)
-                log_stats(stats, file=log)
-            finally:
-                # Copy node logs:
-                logs_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf','logs')
-                log_dir = os.path.join(logs_dir, stats['id'])
-                os.makedirs(log_dir)
-                retrieve_logs(log_dir)
-                revision_config['last_log'] = stats['id']
-                # Tar them for archiving:
-                subprocess.Popen(shlex.split('tar cfvz {id}.tar.gz {id}'.format(id=stats['id'])), cwd=logs_dir).communicate()
-                shutil.rmtree(log_dir)
+            if flamegraph.is_enabled(revision_config):
+                execute(flamegraph.ensure_stopped_perf_agent)
+                execute(flamegraph.start_perf_agent, rev_num)
 
             if capture_fincore:
-                stop_fincore_capture()
-                retrieve_fincore_logs(log_dir)
-                # Restart fincore capture if this is not the last
-                # operation:
-                if operation_i < len(operations):
-                    start_fincore_capture(interval=10)
+                start_fincore_capture(interval=10)
 
-        if flamegraph.is_enabled(revision_config):
-            # Generate and Copy node flamegraphs
-            execute(flamegraph.stop_perf_agent)
-            execute(flamegraph.generate_flamegraph, rev_num)
-            flamegraph_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf', 'flamegraph')
-            flamegraph_test_dir = os.path.join(flamegraph_dir, last_stress_operation_id)
-            retrieve_flamegraph(flamegraph_test_dir, rev_num+1)
-            sh.tar('cfvz', "{}.tar.gz".format(stats['id']), last_stress_operation_id, _cwd=flamegraph_dir)
-            shutil.rmtree(flamegraph_test_dir)
+            last_stress_operation_id = 'None'
+            for operation_i, operation in enumerate(operations, 1):
+                try:
+                    start = datetime.datetime.now()
+                    stats = {
+                        "id": str(uuid.uuid1()),
+                        "type": operation['type'],
+                        "revision": revision,
+                        "git_id": git_id,
+                        "start_date": start.isoformat(),
+                        "label": revision_config.get('label', revision_config['revision']),
+                        "test": '{operation_i}_{operation}'.format(
+                            operation_i=operation_i,
+                            operation=operation['type'])
+                    }
 
-        log_add_data(log, {'title':title,
-                           'subtitle': subtitle,
-                           'revisions': revisions})
+                    if operation['type'] == 'stress':
+                        last_stress_operation_id = stats['id']
+                        # Default to all the nodes of the cluster if no
+                        # nodes were specified in the command:
+                        if operation.has_key('nodes'):
+                            cmd = "{command} -node {hosts}".format(
+                                command=operation['command'],
+                                hosts=",".join(operation['nodes']))
+                        elif '-node' in operation['command']:
+                            cmd = operation['command']
+                        else:
+                            cmd = "{command} -node {hosts}".format(
+                                command=operation['command'],
+                                hosts=",".join([n for n in fab_config['hosts']]))
+                        stats['command'] = cmd
+                        stats['intervals'] = []
+                        stats['test'] = '{operation_i}_{operation}'.format(
+                            operation_i=operation_i, operation=cmd.strip().split(' ')[0]).replace(" ", "_")
+                        logger.info('Running stress operation : {cmd}  ...'.format(cmd=cmd))
+                        # Run stress:
+                        # (stress takes the stats as a parameter, and adds
+                        #  more as it runs):
+                        stress_sha = stress_shas[operation.get('stress_revision', 'default')]
+                        stats = stress(cmd, revision, stress_sha, stats=stats)
+                        # Wait for all compactions to finish (unless disabled):
+                        if operation.get('wait_for_compaction', True):
+                            compaction_throughput = revision_config.get("compaction_throughput_mb_per_sec", 16)
+                            wait_for_compaction(compaction_throughput=compaction_throughput)
 
-        if revisions[-1].get('leave_data', leave_data):
-            teardown(destroy=False, leave_data=True)
-        else:
-            kill_delay = 300 if profiler.yourkit_is_enabled(revision_config) else 0
-            teardown(destroy=True, leave_data=False, kill_delay=kill_delay)
+                    elif operation['type'] == 'nodetool':
+                        if 'nodes' not in operation:
+                            operation['nodes'] = 'all'
+                        if operation['nodes'] in ['all','ALL']:
+                            nodes = [n for n in fab_config['hosts']]
+                        else:
+                            nodes = operation['nodes']
 
-        if profiler.yourkit_is_enabled(revision_config):
-            yourkit_config = profiler.yourkit_get_config()
-            yourkit_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf', 'yourkit')
-            yourkit_test_dir = os.path.join(yourkit_dir, last_stress_operation_id)
-            retrieve_yourkit(yourkit_test_dir, rev_num+1)
-            sh.tar('cfvz', "{}.tar.gz".format(stats['id']),
-                   last_stress_operation_id, _cwd=yourkit_dir)
-            shutil.rmtree(yourkit_test_dir)
+                        set_nodetool_path(os.path.join(product.get_bin_path(), 'nodetool'))
+                        logger.info("Running nodetool on {nodes} with command: {command}".format(nodes=operation['nodes'], command=operation['command']))
+                        stats['command'] = operation['command']
+                        output = nodetool_multi(nodes, operation['command'])
+                        stats['output'] = output
+                        logger.info("Nodetool command finished on all nodes")
+
+                    elif operation['type'] == 'cqlsh':
+                        logger.info("Running cqlsh commands on {node}".format(node=operation['node']))
+                        set_cqlsh_path(os.path.join(product.get_bin_path(), 'cqlsh'))
+                        output = cqlsh(operation['script'], operation['node'])
+                        stats['output'] = output.split("\n")
+                        stats['command'] = operation['script']
+                        logger.info("Cqlsh commands finished")
+
+                    elif operation['type'] == 'bash':
+                        nodes = operation.get('nodes', [n for n in fab_config['hosts']])
+                        logger.info("Running bash commands on: {nodes}".format(nodes=nodes))
+                        stats['output'] = bash(operation['script'], nodes)
+                        stats['command'] = operation['script']
+                        logger.info("Bash commands finished")
+
+                    elif operation['type'] == 'spark_cassandra_stress':
+                        node = operation['node']
+                        logger.info("Running spark_cassandra_stress on {node}".format(node=node))
+                        output = spark_cassandra_stress(operation['script'], node)
+                        stats['output'] = output
+                        logger.info("spark_cassandra_stress finished")
+
+                    elif operation['type'] == 'ctool':
+                        logger.info("Running ctool with parameters: {command}".format(command=operation['command']))
+                        ctool = Ctool(operation['command'], common.config)
+                        output = execute(ctool.run)
+                        stats['output'] = output
+                        logger.info("ctool finished")
+
+                    elif operation['type'] == 'dsetool':
+                        if 'nodes' not in operation:
+                            operation['nodes'] = 'all'
+                        if operation['nodes'] in ['all','ALL']:
+                            nodes = [n for n in fab_config['hosts']]
+                        else:
+                            nodes = operation['nodes']
+
+                        dsetool_options = operation['script']
+                        logger.info("Running dsetool {command} on {nodes}".format(nodes=operation['nodes'], command=dsetool_options))
+                        stats['command'] = dsetool_options
+                        output = dsetool_cmd(nodes=nodes, options=dsetool_options)
+                        stats['output'] = output
+                        logger.info("dsetool command finished on all nodes")
+
+                    elif operation['type'] == 'dse':
+                        logger.info("Running dse command on {node}".format(node=operation['node']))
+                        output = dse_cmd(node=operation['node'], options=operation['script'])
+                        stats['output'] = output.split("\n")
+                        stats['command'] = operation['script']
+                        logger.info("dse commands finished")
+
+                    end = datetime.datetime.now()
+                    stats['end_date'] = end.isoformat()
+                    stats['op_duration'] = str(end - start)
+                    log_stats(stats, file=log)
+                finally:
+                    # Copy node logs:
+                    logs_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf','logs')
+                    log_dir = os.path.join(logs_dir, stats['id'])
+                    os.makedirs(log_dir)
+                    retrieve_logs(log_dir)
+                    revision_config['last_log'] = stats['id']
+                    # Tar them for archiving:
+                    subprocess.Popen(shlex.split('tar cfvz {id}.tar.gz {id}'.format(id=stats['id'])), cwd=logs_dir).communicate()
+                    shutil.rmtree(log_dir)
+
+                if capture_fincore:
+                    stop_fincore_capture()
+                    retrieve_fincore_logs(log_dir)
+                    # Restart fincore capture if this is not the last
+                    # operation:
+                    if operation_i < len(operations):
+                        start_fincore_capture(interval=10)
+
+            if flamegraph.is_enabled(revision_config):
+                # Generate and Copy node flamegraphs
+                execute(flamegraph.stop_perf_agent)
+                execute(flamegraph.generate_flamegraph, rev_num)
+                flamegraph_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf', 'flamegraph')
+                flamegraph_test_dir = os.path.join(flamegraph_dir, last_stress_operation_id)
+                retrieve_flamegraph(flamegraph_test_dir, rev_num+1)
+                sh.tar('cfvz', "{}.tar.gz".format(stats['id']), last_stress_operation_id, _cwd=flamegraph_dir)
+                shutil.rmtree(flamegraph_test_dir)
+
+            log_add_data(log, {'title':title,
+                               'subtitle': subtitle,
+                               'revisions': revisions})
+
+            if revisions[-1].get('leave_data', leave_data):
+                teardown(destroy=False, leave_data=True)
+            else:
+                kill_delay = 300 if profiler.yourkit_is_enabled(revision_config) else 0
+                teardown(destroy=True, leave_data=False, kill_delay=kill_delay)
+
+            if profiler.yourkit_is_enabled(revision_config):
+                yourkit_config = profiler.yourkit_get_config()
+                yourkit_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf', 'yourkit')
+                yourkit_test_dir = os.path.join(yourkit_dir, last_stress_operation_id)
+                retrieve_yourkit(yourkit_test_dir, rev_num+1)
+                sh.tar('cfvz', "{}.tar.gz".format(stats['id']),
+                       last_stress_operation_id, _cwd=yourkit_dir)
+                shutil.rmtree(yourkit_test_dir)
 
 
 def main():


### PR DESCRIPTION
# Commit 1 - making Cancel actually work
Previously, API calls to **/api/tests/status/id/<id>** or **/api/tests/progress/id** would be failing with a **401 - Unauthorized**, because the API user **test-cluster** wouldn't be in the **users** table and also wouldn't have a **role** assigned.

This shows that the API user **test-cluster** by default is not in the **users** table. Also I could not find any documentation for that requirement.
````
select * from cstar_perf.users;

 user_id           | full_name       | roles
-------------------+-----------------+-------------------
  user@example.com |  User Full Name |          {'user'}
 admin@example.com | Admin Full Name | {'admin', 'user'}

(2 rows)
cqlsh> select * from cstar_perf.api_pubkeys ;

 name         | pubkey                                                           | user_type
--------------+------------------------------------------------------------------+-----------
 test-cluster | LrDzaqtOF5t8RDFkqZE3N57biLAaTu+aqXVKK2iuNBCecmnUmHx4tuN89/p56yzB |   cluster
```

After talking to @aboudreault, we kind of came to the conclusion, that we really shouldn't do the role check for the API endpoints that are mentioned here. A simple authentication check should be enough at this point.


Below is an excerpt, showing that the API call to **/api/tests/status/id/<id>** indeed was using the API user **test-cluster** and it would fail with a **401**.
````
INFO:geventwebsocket.handler:172.17.0.2 - - [2016-05-10 17:26:58] "GET /api/tests/status/id/422b7d06-16d4-11e6-8007-0242ac110004 HTTP/1.1" 401 6843 0.051804
DEBUG:geventwebsocket.handler:Initializing WebSocket
DEBUG:geventwebsocket.handler:Validating WebSocket request
INFO:geventwebsocket.handler:172.17.0.2 - - [2016-05-10 17:26:58] "GET /api/login HTTP/1.1" 200 560 0.026101
DEBUG:geventwebsocket.handler:Initializing WebSocket
DEBUG:geventwebsocket.handler:Validating WebSocket request
DEBUG:geventwebsocket.handler:Can only upgrade connection if using GET method.
INFO:geventwebsocket.handler:172.17.0.2 - - [2016-05-10 17:26:58] "POST /api/login HTTP/1.1" 200 451 0.070820
DEBUG:geventwebsocket.handler:Initializing WebSocket
DEBUG:geventwebsocket.handler:Validating WebSocket request
ERROR:cstar_perf.controllers:REQUIRES AUTH
INFO:cstar_perf.controllers:test-cluster
INFO:cstar_perf.controllers:True
INFO:cstar_perf.controllers:<SecureCookieSession {u'logged_in': True, u'_csrf_token': 'T4X5SS94K56O9NV6AJDYCGR85PYIO7LQ', u'user_id': u'test-cluster', u'bypass_csrf': True, u'unsigned_access_token': 'PNT834USH58HNDM0P9B4A0EBN9U6YJLR'}>
INFO:cstar_perf.controllers:<cstar_perf.frontend.lib.crypto.APIKey object at 0x7f61776edc50>
INFO:geventwebsocket.handler:172.17.0.2 - - [2016-05-10 17:26:58] "GET /api/tests/status/id/422b7d06-16d4-11e6-8007-0242ac110004 HTTP/1.1" 401 6843 0.024216
```

PS: This issue happens on a dockerized cstar_perf deployment as well as on the DSE cstar_perf deployment that we have. I think it doesn't happen on cstar.datastax.com because the API user was added to the **users** table.

# Commit 2 - Handling termination from Cancel in a graceful manner
**2)** After solving the **Cancel** problem in the first commit, I finally know now why it actually never attempts to copy back the log files. The problem is that the **JobCancellationTracker** is killing **cassandra-stress** and **stress_compare** (which handles creation of the stats files / copies back the log files / copies the flamegraphs / ...).
Not killing the **stress_compare** process would actually mean that once you hit the Cancel button:
- cassandra-stress will be killed for the current running revision
- log files will be copied back
- next revision will start
- after the sleep period, JobCancellationTracker will detect that the job was cancelled and also kill cassandra-stress of this revision
- this continue until we iterated all revisions.


The **second commit** now handles the termination of **stress_compare** in a graceful manner and tries to finish processing the files of the current running revision.

# Commit 3 - Correctly set the job status to cancelled if it was cancelled by the user

The third commit now correctly sets the job status to **cancelled** in the DB if the job was cancelled by the user.