### PR TITLE
Temporarily use C* python driver 3.2.2

### DIFF
--- a/tool/cstar_perf/docker/cstar_docker.py
+++ b/tool/cstar_perf/docker/cstar_docker.py
@@ -147,7 +147,7 @@ RUN echo "[unix_http_server]" > /supervisord.conf && \
     echo "redirect_stderr=true"                                                             >> /supervisord.conf
 
 ### install the C* driver without any extensions to speed up installation time
-RUN CASS_DRIVER_NO_EXTENSIONS=1 pip install cassandra-driver
+RUN CASS_DRIVER_NO_EXTENSIONS=1 pip install cassandra-driver==3.2.2
 
 CMD ["supervisord", "-n", "-c", "/supervisord.conf"]
 """


### PR DESCRIPTION
With the latest C* python driver version **3.3.0** I noticed some problems with cstar_perf, where the node would constantly be marked as down. I think for now we should stick with the driver version that works, which is **3.2.2**