### PR TITLE
CSTAR-539: Fix stress graph for new format

### DIFF
--- a/frontend/cstar_perf/frontend/static/graph/js/graph.js
+++ b/frontend/cstar_perf/frontend/static/graph/js/graph.js
@@ -290,8 +290,22 @@ var drawGraph = function() {
                 }
             };
 
+            var summaryTableNames = new Set(["op rate", "partition rate", "row rate", "latency mean", "latency median",
+                "latency 95th percentile", "latency 99th percentile", "latency 99.9th percentile", "latency max",
+                "total partitions", "total operation time"]);
+
             //Parse the dates:
             data.forEach(function(d) {
+                // CASSANDRA-11352 slightly changed the format of the stress result table.
+                // For new test runs, data is already written into the DB, where we use all lowercase names for the
+                // stress results table. However, there are already test runs in the DB that do not have all
+                // lowercase names and those numbers won't be shown in the graph.
+                for (var key in d) {
+                    var lowercaseKey = key.toLowerCase();
+                    if (key !== lowercaseKey && summaryTableNames.has(lowercaseKey)) {
+                        d[lowercaseKey] = d[key]
+                    }
+                }
                 d.date = new Date(Date.parse(d.date));
             });
         }
@@ -596,7 +610,7 @@ var drawGraph = function() {
             });
 
             renderLegendText(13, function(title) {
-                return padTextEnd('Total operation time', 26) + ' : ' + data_by_title[title]['Total operation time'];
+                return padTextEnd('total operation time', 26) + ' : ' + data_by_title[title]['total operation time'];
             });
 
             renderLegendText(14, function(title) {

--- a/regression_suites/cstar_perf_regression_monitor.py
+++ b/regression_suites/cstar_perf_regression_monitor.py
@@ -102,7 +102,7 @@ class CstarTestJob(CstarPerfClient):
             s = self.metrics[operation_name]
             for m in self.metrics_list:
                 try:
-                    s[m] = float(operation['op rate'].split(' ')[0])
+                    s[m] = float(operation['op rate'].split(' ')[0].replace(',',''))
                 except KeyError:
                     pass
 

--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -535,8 +535,8 @@ def stress(cmd, revision_tag, stress_sha, stats=None):
             continue
         # Collect aggregates:
         try:
-            stat, value  = line.split(":", 1)
-            stats[stat.strip()] = value.strip()
+            stat, value = line.split(":", 1)
+            stats[stat.strip().lower()] = value.strip()
         except ValueError:
             logger.info("Unable to parse aggregate line: '{}'".format(line))
     log.close()


### PR DESCRIPTION
Since https://issues.apache.org/jira/browse/CASSANDRA-11352 changed how the stress summary table is shown, new test runs all show **undefined** in the graph. The solution to this problem, which is also backward compatible, is quite simple:

- For new test runs, store stress summary entries all with **lowercase** names in **benchmark.py**
- For test runs that are already stored in the DB with **mixed case** names in the summary table, we do a workaround in the **UI** of creating a dict entry with a **lowercase** key. The below picture shows that in the UI, the data object will now have dict keys, where the key has **mixed case** and **lowercase**. If they dict key was already all **lowercase**, we don't modify the dict.

![newgraphs](https://cloud.githubusercontent.com/assets/271029/15241990/b06911cc-18f3-11e6-9b69-950693668f79.png)


@mshuler can you maybe also push your fix for **cstar_perf_regression_monitor.py** to this branch?