### PR TITLE
CSTAR-553: report back Cassandra startup log

### DIFF
--- a/frontend/cstar_perf/frontend/client/client.py
+++ b/frontend/cstar_perf/frontend/client/client.py
@@ -356,6 +356,7 @@ class JobRunner(object):
         # Make a new tarball containing all the revision logs:
         tmptardir = tempfile.mkdtemp()
         try:
+            self._append_startup_logs_to_archivable_system_logs(job['test_id'], log_dir, system_logs)
             job_log_dir = os.path.join(tmptardir, 'cassandra_logs.{test_id}'.format(test_id=job['test_id']))
             os.mkdir(job_log_dir)
             for x, syslog in enumerate(system_logs, 1):
@@ -443,6 +444,17 @@ class JobRunner(object):
         finally:
             with open(os.path.join(job_dir, '0.job_status'), 'w') as f:
                 f.write(final_status)
+
+    def _append_startup_logs_to_archivable_system_logs(self, job_id, log_dir, system_logs):
+        """
+        In case something went wrong during startup of C*, we will basically only have a single tarball
+        with the startup log.
+        """
+        startup_logs_tarball = os.path.join(log_dir, "{name}.tar.gz".format(name=job_id))
+        if os.path.exists(startup_logs_tarball):
+            log.info('Found tarball with startup log at {loc}'.format(loc=startup_logs_tarball))
+            system_logs.append(startup_logs_tarball)
+            log.info('log file locations that will be archived: {logs}'.format(logs=system_logs))
 
     def stream_artifacts(self, job_id):
         """Stream all job artifacts

--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -48,6 +48,8 @@ CASSANDRA_STRESS_PATH = os.path.expanduser("~/fab/stress/")
 CASSANDRA_STRESS_DEFAULT   = os.path.expanduser("~/fab/stress/default/tools/bin/cassandra-stress")
 JAVA_HOME          = os.path.expanduser("~/fab/java")
 
+CSTAR_PERF_LOGS_DIR = os.path.join(os.path.expanduser('~'), '.cstar_perf', 'logs')
+
 antcmd = sh.Command(os.path.join(HOME, 'fab/ant/bin/ant'))
 
 global nodetool_path, cqlsh_path
@@ -211,21 +213,17 @@ def bootstrap(cfg=None, destroy=False, leave_data=False, git_fetch=True):
 def _extract_job_id():
     # this will have a string looking as following: /home/cstar/.cstar_perf/jobs/<jobid>/stats.<jobid>.json
     stats_log = common.config.get('log')
-    # will give us: /home/cstar/.cstar_perf/jobs/<jobid>
-    log_dir = stats_log[0:stats_log.rindex('/')]
     # will give us: <jobid>
-    job_id = log_dir[log_dir.rindex('/') + 1:]
-    return job_id
+    return stats_log.split(os.path.sep)[-2]
 
 
 def retrieve_logs_and_create_tarball(job_id):
-    logs_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf','logs')
-    log_dir = os.path.join(logs_dir, job_id)
+    log_dir = os.path.join(CSTAR_PERF_LOGS_DIR, job_id)
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
     retrieve_logs(log_dir)
     # Tar them for archiving:
-    subprocess.Popen(shlex.split('tar cfvz {id}.tar.gz {id}'.format(id=job_id)), cwd=logs_dir).communicate()
+    subprocess.Popen(shlex.split('tar cfvz {id}.tar.gz {id}'.format(id=job_id)), cwd=CSTAR_PERF_LOGS_DIR).communicate()
     shutil.rmtree(log_dir)
 
 

--- a/tool/cstar_perf/tool/fab_common.py
+++ b/tool/cstar_perf/tool/fab_common.py
@@ -125,6 +125,7 @@ log4j.logger.org.apache.thrift.server.TNonblockingServer=ERROR
 # An error will be raised if a user try to modify these c* config.
 # They can only be set in the cluster config.
 DENIED_CSTAR_CONFIG = ['commitlog_directory', 'data_file_directories', 'saved_caches_directory', 'cdc_directory', 'cdc_overflow_directory']
+CASSANDRA_STARTUP_LOG = os.path.expanduser('~/nohup.out')
 
 ################################################################################
 ### Setup Configuration:
@@ -444,7 +445,7 @@ def destroy(leave_data=False, kill_delay=0):
     fab.run('rm -rf fab/cassandra')
     fab.run('rm -rf fab/dse')
     fab.run('rm -rf fab/scripts')
-    fab.run('rm -f ~/nohup.out')
+    fab.run('rm -f {startup_log}'.format(startup_log=CASSANDRA_STARTUP_LOG))
 
     # Ensure directory configurations look sane
     assert type(config['data_file_directories']) == list
@@ -632,7 +633,7 @@ def copy_logs(local_directory):
         if not os.path.exists(host_log_dir):
             os.makedirs(host_log_dir)
         # copy the node's startup log
-        fab.get(os.path.expanduser("~/nohup.out"), host_log_dir)
+        fab.get(CASSANDRA_STARTUP_LOG, host_log_dir)
         # copy the node's system.log
         fab.get(os.path.join(config['log_dir'], '*'), host_log_dir)
 

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -2,7 +2,7 @@ from benchmark import (bootstrap, stress, nodetool, nodetool_multi, cqlsh, bash,
                        log_stats, log_set_title, log_add_data, retrieve_logs, restart,
                        start_fincore_capture, stop_fincore_capture, retrieve_fincore_logs,
                        drop_page_cache, wait_for_compaction, setup_stress, clean_stress,
-                       get_localhost, retrieve_flamegraph, retrieve_yourkit, dsetool_cmd, dse_cmd)
+                       get_localhost, retrieve_flamegraph, retrieve_yourkit, dsetool_cmd, dse_cmd, CSTAR_PERF_LOGS_DIR)
 from benchmark import config as fab_config, cstar, dse, set_cqlsh_path, set_nodetool_path, spark_cassandra_stress, retrieve_logs_and_create_tarball
 import fab_common as common
 import fab_cassandra as cstar
@@ -332,8 +332,7 @@ def stress_compare(revisions,
 
                 if capture_fincore:
                     stop_fincore_capture()
-                    logs_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf','logs')
-                    log_dir = os.path.join(logs_dir, stats['id'])
+                    log_dir = os.path.join(CSTAR_PERF_LOGS_DIR, stats['id'])
                     retrieve_fincore_logs(log_dir)
                     # Restart fincore capture if this is not the last
                     # operation:

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -3,25 +3,21 @@ from benchmark import (bootstrap, stress, nodetool, nodetool_multi, cqlsh, bash,
                        start_fincore_capture, stop_fincore_capture, retrieve_fincore_logs,
                        drop_page_cache, wait_for_compaction, setup_stress, clean_stress,
                        get_localhost, retrieve_flamegraph, retrieve_yourkit, dsetool_cmd, dse_cmd)
-from benchmark import config as fab_config, cstar, dse, set_cqlsh_path, set_nodetool_path, spark_cassandra_stress
+from benchmark import config as fab_config, cstar, dse, set_cqlsh_path, set_nodetool_path, spark_cassandra_stress, retrieve_logs_and_create_tarball
 import fab_common as common
 import fab_cassandra as cstar
 import fab_flamegraph as flamegraph
 import fab_profiler as profiler
-from fabric import api as fab
 from fabric.tasks import execute
 from command import Ctool
 import os
 import sys
-import time
 import datetime
 import logging
 import copy
 import uuid
 import argparse
 import json
-import subprocess
-import shlex
 import shutil
 import sh
 import distutils.util
@@ -331,17 +327,13 @@ def stress_compare(revisions,
                     log_stats(stats, file=log)
                 finally:
                     # Copy node logs:
-                    logs_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf','logs')
-                    log_dir = os.path.join(logs_dir, stats['id'])
-                    os.makedirs(log_dir)
-                    retrieve_logs(log_dir)
+                    retrieve_logs_and_create_tarball(job_id=stats['id'])
                     revision_config['last_log'] = stats['id']
-                    # Tar them for archiving:
-                    subprocess.Popen(shlex.split('tar cfvz {id}.tar.gz {id}'.format(id=stats['id'])), cwd=logs_dir).communicate()
-                    shutil.rmtree(log_dir)
 
                 if capture_fincore:
                     stop_fincore_capture()
+                    logs_dir = os.path.join(os.path.expanduser('~'),'.cstar_perf','logs')
+                    log_dir = os.path.join(logs_dir, stats['id'])
                     retrieve_fincore_logs(log_dir)
                     # Restart fincore capture if this is not the last
                     # operation:


### PR DESCRIPTION
This PR will now copy/report back the startup log (**nohup.out**) of the Cassandra node. That way it's possible to check e.g. why the JVM startup failed.

The below picture is from a **successful** JVM startup + test run. Both test revisions contain now the startup log:
![successful_test_run](https://cloud.githubusercontent.com/assets/271029/15318234/812e1184-1c25-11e6-8a48-b2c5a6e59ad4.png)

The below picture is from a **non-successful** run. It shows that the first revision was running fine, but the second revision failed **due to invalid JVM settings**. Therefore in the second revision we only have the startup log:
![not_successful_test_run](https://cloud.githubusercontent.com/assets/271029/15318233/81158628-1c25-11e6-881a-37d5a4e9f094.png)
