### PR TITLE
Use fixed names for cstar_perf component logs.

### DIFF
--- a/frontend/supervisord.conf
+++ b/frontend/supervisord.conf
@@ -146,6 +146,7 @@ user=www-data
 autostart=true
 autorestart=true
 redirect_stderr=true
+stdout_logfile=/tmp/cstar_perf_server.log
 
 [program:cstar_perf_notifications]
 environment=PYTHONUNBUFFERED="true"
@@ -154,8 +155,11 @@ user=www-data
 autostart=true
 autorestart=true
 redirect_stderr=true
+stdout_logfile=/tmp/cstar_perf_notifications.log
 
 [eventlistener:crashmail]
 command=crashmail -a -m ryan@datastax.com
 events=PROCESS_STATE
+redirect_stderr=true
+stdout_logfile=/tmp/crashmail.log
 

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -24,7 +24,10 @@ command=cstar_perf_client -s ws://localhost:8000/api/cluster_comms
 autostart=true
 autorestart=true
 redirect_stderr=true
+stdout_logfile=/tmp/cstar_perf_client.log
 
 [eventlistener:crashmail]
 command=crashmail -a -m ryan@datastax.com
 events=PROCESS_STATE
+redirect_stderr=true
+stdout_logfile=/tmp/crashmail.log


### PR DESCRIPTION
The reason why we want to have fixed names instead of the generated log file names (**/tmp/cstar_perf_X-\<someRandomValue\>**), is that once a cstar_perf component is restarted, the log file with the generated name will be overwritten and lost. However, after a restart we would like to be able to still preserve the log file.