### PR TITLE
Don't mark jobs as failed when the client is asking for a new job

### DIFF
--- a/frontend/cstar_perf/frontend/server/cluster_api.py
+++ b/frontend/cstar_perf/frontend/server/cluster_api.py
@@ -139,12 +139,6 @@ def cluster_comms(ws):
             raise UnauthenticatedError("Our peer could not validate our signed auth token")
 
     def get_work(command):
-        # Mark any existing in_process jobs for this cluster as
-        # failed. If the cluster is asking for new work, then these
-        # got dropped on the floor:
-        for test in db.get_in_progress_tests(context['cluster']):
-            db.update_test_status(test['test_id'], 'failed')
-
         # Find the next test scheduled for the client's cluster:
         tests = db.get_scheduled_tests(context['cluster'], limit=1)
         if len(tests) > 0:

--- a/frontend/cstar_perf/frontend/server/model.py
+++ b/frontend/cstar_perf/frontend/server/model.py
@@ -292,6 +292,7 @@ class Model(object):
         test = self.get_test(test_id)
         original_status = self.get_test_status(test_id)
         # Update tests table:
+        log.info('Updating test status of {test_id}. Original status: {orig}. New status: {status}.'.format(test_id=test_id, orig=original_status, status=status))
         if status == "completed":
             completed_date = uuid.uuid1()
             session.execute(self.__prepared_statements['update_test_set_status_completed'], (status, completed_date, test_id ))
@@ -304,7 +305,7 @@ class Model(object):
         # Add the new status to test_status:
         session.execute(self.__prepared_statements['insert_test_status'], (status, test['cluster'], test_id, test['user'], test['test_definition']['title']))
         self.zmq_socket.send_string("{status} {cluster} {test_id}".format(status=status, cluster=test['cluster'], test_id=test_id))
-        log.info("test status is: {status}".format(status=status))
+        log.info("test status of {test_id} is: {status}".format(status=status, test_id=test_id))
 
         # Send the user an email when the status updates:
         if self.email_notifications and status not in ('scheduled','in_progress') and status != original_status:


### PR DESCRIPTION
I think this is a potential **new race condition**, which might be introduced with #204. The new behavior that came with #204 is that **[terminate()](https://github.com/datastax/cstar_perf/blob/master/frontend/cstar_perf/frontend/client/client.py#L788)** is used in order to perform a graceful shutdown of **cstar_perf_stress** (which calls **stress_compare**). This graceful shutdown is needed to grab the logs in case the job failed / got cancelled. The side effect of this is that it takes a bit longer to write results to the DB and eventually mark a job as **completed**.

If we look closely at the logs, Line **4** clearly tells that the job **completed**. In Line **5** the client asks for another job by executing **get_work()** from **cluster_api.py**. However, if the client detects that there are still jobs **in_progress**, it will mark them as **failed**, which isn't correct IMO. Line **9** shows that the new state of the job indeed changed to **failed**.

If the **completed** state wasn't written fast enough to the DB, a job can be marked as **failed** by the client, even though there was no failure (this is what was happening in my case)

````
1. DEBUG:cstar_perf.client:Sending job completion message for b674c67c-1da5-11e6-976c-0cc47a4e5c68 ...
2. DEBUG:cstar_perf.socket_comms:Sending command : {"action": "test_done", "status": "completed", "test_id": "b674c67c-1da5-11e6-976c-0cc47a4e5c68", "type": "command", "command_id": "44db6632-1da6-11e6-bf82-0cc47a4e5c68"}
3. DEBUG:cstar_perf.socket_comms:Received response : {u'type': u'response', u'message': u'test_update', u'test_id': u'b674c67c-1da5-11e6-976c-0cc47a4e5c68', u'done': True, u'command_id': u'44db6632-1da6-11e6-bf82-0cc47a4e5c68'}
4. DEBUG:cstar_perf.client:Server confirms job b674c67c-1da5-11e6-976c-0cc47a4e5c68 is complete.
5. DEBUG:cstar_perf.client:Asking for a new job...
6. DEBUG:cstar_perf.socket_comms:Sending command : {"action": "get_work", "type": "command", "command_id": "44e217e8-1da6-11e6-bf82-0cc47a4e5c68"}
7. DEBUG:urllib3.connectionpool:Setting read timeout to None
8. DEBUG:urllib3.connectionpool:"GET /api/tests/status/id/b674c67c-1da5-11e6-976c-0cc47a4e5c68 HTTP/1.1" 200 24
9. DEBUG:cstar_perf.client:JobCancellationTracker -- status of test_id b674c67c-1da5-11e6-976c-0cc47a4e5c68 is: {u'status': u'failed'}
````

The changes in **model.py** are only to improve debugging and write more meaningful information to the logs.