### PR TITLE
add josh-mckenzie to fab_common users

### DIFF
--- a/tool/cstar_perf/tool/fab_common.py
+++ b/tool/cstar_perf/tool/fab_common.py
@@ -52,6 +52,7 @@ git_repos = [
     ('shawnkumar',    'git://github.com/shawnkumar/cassandra.git'),
     ('mambocab',      'git://github.com/mambocab/cassandra.git'),
     ('jbellis',       'git://github.com/jbellis/cassandra.git'),
+    ('josh-mckenzie', 'git@github.com:josh-mckenzie/cassandra.git'),
     ('marcuse',       'git://github.com/krummas/cassandra.git'),
     ('pcmanus',       'git://github.com/pcmanus/cassandra.git'),
     ('belliottsmith', 'git://github.com/belliottsmith/cassandra.git'),


### PR DESCRIPTION
I already did this for `fab_cassandra.py` without making a PR, which was a mistake (see a9d51f4966e730b044873630964e4de3ba9d4991). @mshuler can you sanity-check, merge, and deploy, please?