### PR TITLE
Define hints_directory in cluster_config for docker

### DIFF
--- a/tool/cstar_perf/docker/cstar_docker.py
+++ b/tool/cstar_perf/docker/cstar_docker.py
@@ -490,7 +490,8 @@ def __install_cstar_perf_tool(cluster_name, hosts, mount_host_src=False, first_c
         "saved_caches_directory": '/data/cstar_perf/saved_caches',
         'cdc_directory': '/data/cstar_perf/cdc',
         'cdc_overflow_directory': '/data/cstar_perf/cdc_overflow',
-        "docker": True
+        "docker": True,
+        "hints_directory": "/data/cstar_perf/hints"
     }
     
     with fab.settings(hosts=first_node):


### PR DESCRIPTION
DSE startup might fail due to permission issues when creating the hints directory at the default location (/var/lib/cassandra/hints), therefore we specify **hints_directory** for Docker in the **cluster_config.json** file.

@mambocab @mshuler can you review please?