### PR TITLE
Adding solr stress operations

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,7 +18,7 @@ Requirements:
 
 Ubuntu dependencies:
 
-    sudo apt-get install python2.7 python2.7-dev python-virtualenv libtool cassandra
+    sudo apt-get install python2.7 python2.7-dev python-virtualenv libtool cassandra curl
 
 Setup a virtual environment:
 

--- a/frontend/cstar_perf/frontend/client/client.py
+++ b/frontend/cstar_perf/frontend/client/client.py
@@ -519,6 +519,7 @@ class JobRunner(object):
                 ('flamegraph_logs', 'flamegraph_logs.{job_id}.tar.gz', True),
                 ('flamegraph', 'flamegraph_{job_id}*.svg', False),
                 ('yourkit', 'yourkit.{job_id}.tar.gz', True),
+                ('exceptions', 'exceptions.log', False),
                 ('operations', 'operation*', False),
         ):
             stream(kind, pattern, binary)

--- a/frontend/cstar_perf/frontend/client/client.py
+++ b/frontend/cstar_perf/frontend/client/client.py
@@ -323,6 +323,7 @@ class JobRunner(object):
         log_dir = CSTAR_PERF_LOGS_DIR
         flamegraph_dir = os.path.join(os.path.expanduser("~"), '.cstar_perf', 'flamegraph')
         yourkit_dir = os.path.join(os.path.expanduser("~"), '.cstar_perf', 'yourkit')
+        operation_artifacts_dir = os.path.join(os.path.expanduser("~"), '.cstar_perf', 'operation_artifacts')
         #Create a stats summary file without voluminous interval data
         if os.path.isfile(stats_path):
             with open(stats_path) as stats:
@@ -424,6 +425,13 @@ class JobRunner(object):
             finally:
                 shutil.rmtree(tmptardir)
 
+        if os.path.exists(operation_artifacts_dir):
+            for file_ in os.listdir(operation_artifacts_dir):
+                filepath = os.path.join(operation_artifacts_dir, file_)
+                shutil.move(filepath, job_dir)
+            shutil.rmtree(operation_artifacts_dir)
+
+
         ## Stream artifacts
         ## Write final job status to 0.job_status file
         final_status = 'local_complete'
@@ -510,7 +518,9 @@ class JobRunner(object):
                 ('system_logs', 'cassandra_logs.{job_id}.tar.gz', True),
                 ('flamegraph_logs', 'flamegraph_logs.{job_id}.tar.gz', True),
                 ('flamegraph', 'flamegraph_{job_id}*.svg', False),
-                ('yourkit', 'yourkit.{job_id}.tar.gz', True)):
+                ('yourkit', 'yourkit.{job_id}.tar.gz', True),
+                ('operations', 'operation*', False),
+        ):
             stream(kind, pattern, binary)
 
         return namedtuple('StreamedArtifacts', 'streamed failed missing')(streamed, failed, missing)

--- a/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
+++ b/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
@@ -129,13 +129,13 @@ h3 {
       {% if op['args'] %}
       <tr><td>Args</td><td><code>{{op['args']}}</code></td></tr>
       {% endif %}
-      {% for solr_artifact in ['schema', 'solrconfig', 'cql', 'testdata'] %}
-        {% if op[solr_artifact] %}
-          {% set link_title = op[solr_artifact] if op[solr_artifact][-4:] in ['.xml', '.txt', '.cql'] else solr_artifact %}
+      {% for solr_artifact in ['schema', 'solrconfig', 'cql', 'testdata', 'exceptions.log'] %}
+        {% if cur_artifacts.has_key(solr_artifact) %}
+          {% set link_title = op[solr_artifact] if op.has_key(solr_artifact) and op[solr_artifact][-4:] in ['.xml', '.txt', '.cql', '.log'] else solr_artifact %}
           {% if cur_artifacts[solr_artifact] %}
             <tr><td>{{solr_artifact.capitalize()}}</td><td><a href='/tests/artifacts/{{test['test_id']}}/{{cur_artifacts[solr_artifact]['artifact_type']}}/{{cur_artifacts[solr_artifact]['name']}}'>{{link_title}}</a></td></tr>
           {% else %}
-            <tr><td>Create table script</td><td>{{link_title}} currently unavailable...</a></td></tr>
+            <tr><td>{{solr_artifact.capitalize()}}</td><td>{{link_title}} currently unavailable...</a></td></tr>
           {% endif %}
         {% endif %}
       {% endfor %}

--- a/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
+++ b/frontend/cstar_perf/frontend/server/templates/view_test.jinja2.html
@@ -77,7 +77,7 @@ h3 {
        <td><a href='/tests/artifacts/{{test['test_id']}}/{{artifact['artifact_type']}}/{{artifact['name']}}'>{{artifact['name']}}</a></td>
        <td></td>
      </tr>
-   {% endif %} 
+   {% endif %}
   {% endfor %}
 </td></tr></table>
 {% endif %}
@@ -115,6 +115,7 @@ h3 {
 <tr><th colspan="100%">Operations</th></tr>
 {% for op_n in range(test['test_definition']['operations']|length) %}
   {% set op = test['test_definition']['operations'][op_n] %}
+  {% set cur_artifacts = op_artifacts[op_n + 1] %}
   <tr><td>Operation {{op_n + 1}}</td><td>
     <table class='table'>
       <tr><td class='col-md-2'>Operation</td><td><b>{{op['operation']}}</b></td></tr>
@@ -124,14 +125,32 @@ h3 {
       {% if op['script'] %}
         <tr><td>Script</td><td><code>{{op['script']}}</code></td></tr>
       {% endif %}
+      <!-- Some solr specific stuff here... -->
+      {% if op['args'] %}
+      <tr><td>Args</td><td><code>{{op['args']}}</code></td></tr>
+      {% endif %}
+      {% for solr_artifact in ['schema', 'solrconfig', 'cql', 'testdata'] %}
+        {% if op[solr_artifact] %}
+          {% set link_title = op[solr_artifact] if op[solr_artifact][-4:] in ['.xml', '.txt', '.cql'] else solr_artifact %}
+          {% if cur_artifacts[solr_artifact] %}
+            <tr><td>{{solr_artifact.capitalize()}}</td><td><a href='/tests/artifacts/{{test['test_id']}}/{{cur_artifacts[solr_artifact]['artifact_type']}}/{{cur_artifacts[solr_artifact]['name']}}'>{{link_title}}</a></td></tr>
+          {% else %}
+            <tr><td>Create table script</td><td>{{link_title}} currently unavailable...</a></td></tr>
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+      {% if op['core'] %}
+      <tr><td>Core</td><td><code>{{op['core']}}</code></td></tr>
+      {% endif %}
+      <!-- end of solr specific stuff -->
       {% if op['nodes'] %}
         <tr><td>Nodes</td><td><code>{{op['nodes']}}</code></td></tr>
       {% endif %}
       {% if op['node'] %}
-        <tr><td>node</td><td><code>{{op['node']}}</code></td></tr>
+        <tr><td>Node</td><td><code>{{op['node']}}</code></td></tr>
       {% endif %}
       {% if op.has_key('wait_for_compaction') %}
-        <tr><td>wait for compactions</td><td>{{op['wait_for_compaction']}}</td></tr>
+        <tr><td>Wait for compactions</td><td>{{op['wait_for_compaction']}}</td></tr>
       {% endif %}
     </table>
   </td></tr>

--- a/frontend/cstar_perf/frontend/static/css/app.css
+++ b/frontend/cstar_perf/frontend/static/css/app.css
@@ -70,3 +70,7 @@ body {
     font-weight: bold;
     font-size: 1.1em;    
 }
+
+.solr-stress-text {
+    display: none;
+}

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -154,6 +154,8 @@ var addOperationDiv = function(animate, operationDefaults){
         "            <option value='cqlsh'>cqlsh</option>" +
         "            <option value='bash'>bash</option>" +
         "            <option id='{operation_id}-spark_cassandra_stress_select' value='spark_cassandra_stress'>spark-cassandra-stress</option>" +
+        "            <option id='{operation_id}-solr_create_schema_select' value='solr_create_schema'>solr create-schema.sh</option>" +
+        "            <option id='{operation_id}-solr_run_benchmark_select' value='solr_run_benchmark'>solr run-benchmark.sh</option>" +
         "            <option value='ctool'>ctool</option>" +
         "            <option id='{operation_id}-dsetool_select' value='dsetool'>dsetool</option>" +
         "            <option id='{operation_id}-dse_select' value='dse'>dse</option>" +
@@ -241,6 +243,110 @@ var addOperationDiv = function(animate, operationDefaults){
         "        </div>" +
         "      </div>" +
         "            " +
+        "      <div class='form-group args solr_create_schema'> " +
+        "        <label class='col-md-3 control-label' for='{operation_id}-command'>" +
+        "          Schema</label>" +
+        "        <div class='col-md-9'>" +
+        "          <select class='form-control solr-stress-combo schema-combo' id='{operation_id}-schema-combo'>" +
+        "            <option value='schema.xml'>schema.xml</option>" +
+        "            <option value='schema_geo.xml'>schema_geo.xml</option>" +
+        "            <option value='custom'>custom</option>" +
+        "          </select>" +
+        "          <textarea id='{operation_id}-schema-text' type='text'" +
+        "            class='form-control input-md solr-stress-text schema-text' required=''></textarea>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group args solr_create_schema'> " +
+        "        <label class='col-md-3 control-label' for='{operation_id}-command'>" +
+        "          SolrConfig</label>" +
+        "        <div class='col-md-9'>" +
+        "          <select class='form-control solr-stress-combo solrconfig-combo' id='{operation_id}-solrconfig-combo'>" +
+        "            <option value='solrconfig.xml'>solrconfig.xml</option>" +
+        "            <option value='solrconfig-rt.xml'>solrconfig-rt.xml</option>" +
+        "            <option value='custom'>custom</option>" +
+        "          </select>" +
+        "          <textarea id='{operation_id}-solrconfig-text' type='text'" +
+        "            class='form-control input-md solr-stress-text solrconfig-text' required=''></textarea>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group args solr_create_schema'> " +
+        "        <label class='col-md-3 control-label' for='{operation_id}-command'>" +
+        "          Table Creation CQL</label>" +
+        "        <div class='col-md-9'>" +
+        "          <select class='form-control solr-stress-combo createtable-combo' id='{operation_id}-createtable-combo'>" +
+        "            <option value='create_table.cql'>create_table.cql</option>" +
+        "            <option value='create_table_geo.cql'>create_table_geo.cql</option>" +
+        "            <option value='create_table_geo_rt.cql'>create_table_geo_rt.cql</option>" +
+        "            <option value='custom'>custom</option>" +
+        "          </select>" +
+        "          <textarea id='{operation_id}-createtable-text' type='text'" +
+        "            class='form-control input-md solr-stress-text createtable-text' required=''></textarea>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group args solr_create_schema'> " +
+        "        <label class='col-md-3 control-label' for='{operation_id}-command'>" +
+        "          Core</label>" +
+        "        <div class='col-md-9'>" +
+        "          <select class='form-control solr-stress-combo core-combo' id='{operation_id}-core-combo'>" +
+        "            <option value='demo.solr'>demo.solr</option>" +
+        "            <option value='demo.geo'>demo.geo</option>" +
+        "            <option value='custom'>custom</option>" +
+        "          </select>" +
+        "          <textarea id='{operation_id}-core-text' type='text'" +
+        "            class='form-control input-md solr-stress-text core-text' required=''></textarea>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group nodes solr_create_schema'>" +
+        "        <label class='col-md-3 control-label'" +
+        "            for='{operation_id}-command'>Node</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <select id='{operation_id}-nodes' type='text'" +
+        "               class='form-control input-md node-create-schema node-select'>" +
+        "          </select>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group args solr_run_benchmark'> " +
+        "        <label class='col-md-3 control-label' for='{operation_id}-command'>" +
+        "          --test-data</label>" +
+        "        <div class='col-md-9'>" +
+        "          <select class='form-control solr-stress-combo run-benchmark-combo' id='{operation_id}-run-benchmark-combo'>" +
+        "            <option value='testMixed.txt'>testMixed.txt</option>" +
+        "            <option value='testCqlQuery.txt'>testCqlQuery.txt</option>" +
+        "            <option value='testCqlWrite.txt'>testCqlWrite.txt</option>" +
+        "            <option value='testGenerateIndexLatencyTest.txt'>testGenerateIndexLatencyTest.txt</option>" +
+        "            <option value='testGenerateQueries.txt'>testGenerateQueries.txt</option>" +
+        "            <option value='testLoadGeoCql.txt'>testLoadGeoCql.txt</option>" +
+        "            <option value='testLoadGeoHttp.txt'>testLoadGeoHttp.txt</option>" +
+        "            <option value='testLucRead.txt'>testLucRead.txt</option>" +
+        "            <option value='testMixed.txt'>testMixed.txt</option>" +
+        "            <option value='testPSTMNTS.txt'>testPSTMNTS.txt</option>" +
+        "            <option value='testQuery.txt'>testQuery.txt</option>" +
+        "            <option value='testUpdate.txt'>testUpdate.txt</option>" +
+        "            <option value='testWrite.txt'>testWrite.txt</option>" +
+        "            <option value='custom'>custom</option>" +
+        "          </select>" +
+        "          <textarea id='{operation_id}-run-benchmark-text' type='text'" +
+        "            class='form-control input-md solr-stress-text run-benchmark-text' required=''></textarea>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group args solr_run_benchmark'>" +
+        "        <label class='col-md-3 control-label'" +
+        "            for='{operation_id}-command'>Additional Arguments</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <textarea id='{operation_id}-args' type='text'" +
+        "               class='form-control input-md args-run-benchmark' required=''>{solr_run_benchmark_args}</textarea>" +
+        "        </div>" +
+        "      </div>" +
+        "      <div class='form-group nodes solr_run_benchmark'>" +
+        "        <label class='col-md-3 control-label'" +
+        "            for='{operation_id}-command'>Node</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <select id='{operation_id}-nodes' type='text'" +
+        "               class='form-control input-md node-solr-stress node-select'>" +
+        "          </select>" +
+        "        </div>" +
+        "      </div>" +
+        "            " +       
         "      <div class='form-group type dsetool'>" +
         "        <label class='col-md-3 control-label'" +
         "        for='{operation_id}-command'>dsetool Command</label>  " +
@@ -395,6 +501,11 @@ var addOperationDiv = function(animate, operationDefaults){
     } else {
         newOperation.script_spark_cassandra_stress = "-o 10000 -y 1000 -p 1000 writeperfrow";
     }
+    if (newOperation.operationType === 'solr_run_benchmark' && operationDefaults.script) {
+        newOperation.solr_run_benchmark_args = operationDefaults.script;
+    } else {
+        newOperation.solr_run_benchmark_args = "--clients 1 --loops 1 --solr-core demo.solr --url http://testcluster-01:8983"
+    }
     if (newOperation.operationType === 'dsetool' && operationDefaults.script) {
         newOperation.script_dsetool = operationDefaults.script;
     } else {
@@ -411,7 +522,8 @@ var addOperationDiv = function(animate, operationDefaults){
         newDiv.hide();
     $("#schedule-operations").append(newDiv);
     $("#"+operation_id+"-type").change(function(){
-        var validOperations = ['stress', 'nodetool', 'cqlsh', 'bash', 'spark_cassandra_stress', 'ctool', 'dsetool', 'dse'];
+        var validOperations = ['stress', 'nodetool', 'cqlsh', 'bash', 'spark_cassandra_stress', 'ctool', 'dsetool',
+            'dse', 'solr_create_schema', 'solr_run_benchmark'];
         if (validOperations.indexOf(this.value) < 0) {
             console.log(this.value + ' not a valid selection')
         }
@@ -454,7 +566,7 @@ var maybe_show_dse_operations = function() {
             break;
         }
     }
-    var operation_type = ['spark_cassandra_stress', 'dsetool', 'dse'];
+    var operation_type = ['spark_cassandra_stress', 'dsetool', 'dse', 'solr_create_schema', 'solr_run_benchmark'];
     for (var idx = 0; idx < operation_type.length; idx++) {
         var op = operation_type[idx];
         for (var i = 1; i <= $('.operation-type').length; i++) {
@@ -487,6 +599,17 @@ var maybe_show_dse_options = function(id, value) {
         $("#" + spark_env_div_id).hide();
     }
     maybe_show_dse_operations();
+};
+
+var get_associated_text_id = function(combo_element) {
+    return combo_element.attr('id').replace('combo', 'text')
+};
+
+var get_solr_text = function(combo_element) {
+    if (combo_element.val() === 'custom') {
+        return $('#' + get_associated_text_id(combo_element)).val()
+    }
+    return combo_element.val()
 };
 
 var createJob = function() {
@@ -552,6 +675,18 @@ var createJob = function() {
         if (op === "spark_cassandra_stress") {
             jobSpec['script'] = operation.find(".script-spark-cassandra-stress").val();
             jobSpec['node'] = operation.find(".node-spark-cassandra-stress").val();
+        }
+        if (op === "solr_create_schema") {
+            jobSpec['schema'] = get_solr_text(operation.find(".schema-combo"));
+            jobSpec['solrconfig'] = get_solr_text(operation.find(".solrconfig-combo"));
+            jobSpec['cql'] = get_solr_text(operation.find(".createtable-combo"));
+            jobSpec['core'] = get_solr_text(operation.find(".core-combo"));
+            jobSpec['node'] = operation.find(".node-create-schema").val();
+        }
+        if (op === "solr_run_benchmark") {
+            jobSpec['testdata'] = get_solr_text(operation.find(".run-benchmark-combo"));
+            jobSpec['args'] = operation.find(".args-run-benchmark").val();
+            jobSpec['node'] = operation.find(".node-solr-stress").val();
         }
         if (op === "dsetool") {
             jobSpec['script'] = operation.find(".script-dsetool").val();
@@ -629,6 +764,9 @@ var cloneExistingJob = function(job_id) {
             show_job_json();
         }
 
+        // Since we dynamically added some divs, we need to attach events
+        // that would normally be triggered on document load
+        attachSolrComboEvents()
    });
 };
 
@@ -725,6 +863,16 @@ var updateURLBar = function(query) {
     window.history.replaceState(null,null,parseUri(location).path + "?" + $.param(query));
 };
 
+var attachSolrComboEvents = function() {
+    $('.solr-stress-combo').change(function(e) {
+        var related_text_id = get_associated_text_id($(this))
+        if ($(this).val() === 'custom') {
+            $('#' + related_text_id).show()
+        } else {
+            $('#' + related_text_id).hide()
+        }
+    })
+}
 
 $(document).ready(function() {
     //Add revision button callback:
@@ -783,4 +931,5 @@ $(document).ready(function() {
         e.preventDefault();
     });
 
+    attachSolrComboEvents()
 });

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -333,6 +333,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "            <option value='testQuery.txt'>testQuery.txt</option>" +
         "            <option value='testUpdate.txt'>testUpdate.txt</option>" +
         "            <option value='testWrite.txt'>testWrite.txt</option>" +
+        "            <option value='queries-cql.txt'>queries-cql.txt</option>" +
         "            <option value='custom'>custom</option>" +
         "          </select>" +
         "          <textarea id='{operation_id}-run-benchmark-text' type='text'" +
@@ -497,6 +498,7 @@ var addOperationDiv = function(animate, operationDefaults){
         ['solr_create_schema', 'cql', 'cql', 'create_table.cql'],
         ['solr_create_schema', 'core', 'core', 'demo.solr'],
         ['solr_run_benchmark', 'testdata', 'testdata', 'testMixed.txt'],
+        ['solr_run_benchmark', 'args', 'run_benchmark_args', '--clients 1 --loops 1 --solr-core demo.solr --url http://{node}:8983'],
     ];
     property_defaults.forEach(function(row) {
        if (newOperation.operationType === row[0] && row[1] in operationDefaults) {
@@ -555,25 +557,32 @@ var select_solr_defaults = function(newOperation) {
     if (newOperation.operationType === 'solr_create_schema') {
         var create_schema_args = ["schema", "solrconfig", "cql", "core"];
         create_schema_args.forEach(function(arg) {
-            if ( $("." + arg + "-combo option[value='" + newOperation[arg] + "']").length == 0) {
-                $("." + arg + "-combo").val("custom").change();
-                $("." + arg + "-text").val(newOperation[arg]);
+            var id_prefix = "{id}-{arg}".format({"id": newOperation["operation_id"], "arg": arg});
+            if ( $("#{id}-combo option[value='{value}']".format({"id": id_prefix, "value": newOperation[arg]})).length == 0) {
+                $("#{id}-combo".format({"id": id_prefix})).val("custom").change();
+                $("#{id}-text".format({"id": id_prefix})).val(newOperation[arg]);
             } else {
-                $("." + arg + "-combo").val(newOperation[arg]).change();
+                $("#{id}-combo".format({"id": id_prefix})).val(newOperation[arg]).change();
             }
         });
     }
     else if (newOperation.operationType === 'solr_run_benchmark') {
-        if ( $(".run-benchmark-combo option[value='" + newOperation.testdata + "']").length == 0) {
-            $(".run-benchmark-combo").val("custom").change();
-            $(".run-benchmark-text").val(newOperation.testdata);
+        var op_id = newOperation["operation_id"];
+        if ($("#{id}-run-benchmark-combo option[value='{value}']".format({
+                "id": op_id,
+                "value": newOperation.testdata
+            })).length == 0) {
+            $("#{id}-run-benchmark-combo".format({"id": op_id})).val("custom").change();
+            $("#{id}-run-benchmark-text".format({"id": op_id})).val(newOperation.testdata);
         } else {
-            $(".run-benchmark-combo").val(newOperation.testdata).change();
+            $("#{id}-run-benchmark-combo".format({"id": op_id})).val(newOperation.testdata).change();
         }
     }
+
     $.get("/api/clusters/" + $("#cluster").val(), function(data) {
-        var args = $("#" + newOperation.operation_id + "-args");
-        args.val("--clients 1 --loops 1 --solr-core demo.solr " + "--url http://" + data["nodes"][0] + ":8983");
+        var args = $("#" + newOperation["operation_id"] + "-args");
+        // args.val("--clients 1 --loops 1 --solr-core demo.solr " + "--url http://" + data["nodes"][0] + ":8983");
+        args.val(newOperation["run_benchmark_args"].format({"node": data["nodes"][0]}));
     });
 };
 

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -334,7 +334,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "            for='{operation_id}-command'>Additional Arguments</label>  " +
         "        <div class='col-md-9'>" +
         "          <textarea id='{operation_id}-args' type='text'" +
-        "               class='form-control input-md args-run-benchmark' required=''>{run_benchmark_args}</textarea>" +
+        "               class='form-control input-md args-run-benchmark' required=''></textarea>" +
         "        </div>" +
         "      </div>" +
         "      <div class='form-group nodes solr_run_benchmark'>" +
@@ -486,7 +486,6 @@ var addOperationDiv = function(animate, operationDefaults){
         ['solr_create_schema', 'solrconfig', 'solrconfig', 'solrconfig.xml'],
         ['solr_create_schema', 'cql', 'cql', 'create_table.cql'],
         ['solr_create_schema', 'core', 'core', 'demo.solr'],
-        ['solr_run_benchmark', 'args', 'run_benchmark_args', '--clients 1 --loops 1 --solr-core demo.solr --url http://testcluster-01:8983'],
         ['solr_run_benchmark', 'testdata', 'testdata', 'testMixed.txt'],
     ];
     property_defaults.forEach(function(row) {
@@ -562,6 +561,10 @@ var select_solr_defaults = function(newOperation) {
             $(".run-benchmark-combo").val(newOperation.testdata).change();
         }
     }
+    $.get("/api/clusters/" + $("#cluster").val(), function(data) {
+        var args = $("#" + newOperation.operation_id + "-args");
+        args.val("--clients 1 --loops 1 --solr-core demo.solr " + "--url http://" + data["nodes"][0] + ":8983");
+    });
 };
 
 var maybe_show_dse_operations = function() {

--- a/frontend/cstar_perf/frontend/static/js/schedule.js
+++ b/frontend/cstar_perf/frontend/static/js/schedule.js
@@ -154,6 +154,7 @@ var addOperationDiv = function(animate, operationDefaults){
         "            <option value='cqlsh'>cqlsh</option>" +
         "            <option value='bash'>bash</option>" +
         "            <option id='{operation_id}-spark_cassandra_stress_select' value='spark_cassandra_stress'>spark-cassandra-stress</option>" +
+        "            <option id='{operation_id}-solr_download_geonames_select' value='solr_download_geonames'>solr download-geonames.sh</option>" +
         "            <option id='{operation_id}-solr_create_schema_select' value='solr_create_schema'>solr create-schema.sh</option>" +
         "            <option id='{operation_id}-solr_run_benchmark_select' value='solr_run_benchmark'>solr run-benchmark.sh</option>" +
         "            <option value='ctool'>ctool</option>" +
@@ -243,6 +244,15 @@ var addOperationDiv = function(animate, operationDefaults){
         "        </div>" +
         "      </div>" +
         "            " +
+        "      <div class='form-group nodes solr_download_geonames'>" +
+        "        <label class='col-md-3 control-label'" +
+        "            for='{operation_id}-command'>Node</label>  " +
+        "        <div class='col-md-9'>" +
+        "          <select id='{operation_id}-nodes' type='text'" +
+        "               class='form-control input-md node-download-geonames node-select'>" +
+        "          </select>" +
+        "        </div>" +
+        "      </div>" +
         "      <div class='form-group args solr_create_schema'> " +
         "        <label class='col-md-3 control-label' for='{operation_id}-command'>" +
         "          Schema</label>" +
@@ -508,7 +518,7 @@ var addOperationDiv = function(animate, operationDefaults){
 
     $("#"+operation_id+"-type").change(function(){
         var validOperations = ['stress', 'nodetool', 'cqlsh', 'bash', 'spark_cassandra_stress', 'ctool', 'dsetool',
-            'dse', 'solr_create_schema', 'solr_run_benchmark'];
+            'dse', 'solr_download_geonames', 'solr_create_schema', 'solr_run_benchmark'];
         if (validOperations.indexOf(this.value) < 0) {
             console.log(this.value + ' not a valid selection')
         }
@@ -577,7 +587,7 @@ var maybe_show_dse_operations = function() {
             break;
         }
     }
-    var operation_type = ['spark_cassandra_stress', 'dsetool', 'dse', 'solr_create_schema', 'solr_run_benchmark'];
+    var operation_type = ['spark_cassandra_stress', 'dsetool', 'dse', 'solr_download_geonames', 'solr_create_schema', 'solr_run_benchmark'];
     for (var idx = 0; idx < operation_type.length; idx++) {
         var op = operation_type[idx];
         for (var i = 1; i <= $('.operation-type').length; i++) {
@@ -686,6 +696,9 @@ var createJob = function() {
         if (op === "spark_cassandra_stress") {
             jobSpec['script'] = operation.find(".script-spark-cassandra-stress").val();
             jobSpec['node'] = operation.find(".node-spark-cassandra-stress").val();
+        }
+        if (op === "solr_download_geonames") {
+            jobSpec['node'] = operation.find(".node-download-geonames").val();
         }
         if (op === "solr_create_schema") {
             jobSpec['schema'] = get_solr_text(operation.find(".schema-combo"));

--- a/tool/cstar_perf/docker/cstar_docker.py
+++ b/tool/cstar_perf/docker/cstar_docker.py
@@ -58,7 +58,8 @@ RUN \
       psmisc \
       python-software-properties \
       libjpeg-dev \
-      lxc
+      lxc \
+      curl
 
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
     add-apt-repository ppa:webupd8team/java && \

--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -371,6 +371,13 @@ def _create_operation_working_directory(operation_id, node):
     return operation_dir
 
 
+def solr_download_geonames(node):
+    solr_stress_path = os.path.join(dse.get_dse_path(), 'demos', 'solr_stress')
+    with common.fab.settings(fab.show('warnings', 'running', 'stdout', 'stderr'), hosts=node):
+        result = execute(fab.run, 'cd {path}; ./download-geonames.sh'.format(path=solr_stress_path))
+    return result
+
+
 def solr_create_schema(operation_id, operation_num, schema, solrconfig, cql, core, node):
     operation_dir = _create_operation_working_directory(operation_id, node)
     schema_path = os.path.join(dse.get_dse_path(), 'demos', 'solr_stress', 'resources', 'schema')

--- a/tool/cstar_perf/tool/benchmark.py
+++ b/tool/cstar_perf/tool/benchmark.py
@@ -355,8 +355,7 @@ def _remove_operation_dir(operation_dir, node):
         execute(fab.run, 'rm -r {}'.format(operation_dir))
 
 
-def retrieve_solr_logs(operation_num, configs):
-    local_dir = os.path.join(os.path.expanduser('~'), '.cstar_perf/operation_artifacts')
+def _retrieve_solr_logs(operation_num, configs, local_dir):
     if not os.path.exists(local_dir):
         os.makedirs(local_dir)
 
@@ -388,7 +387,8 @@ def solr_create_schema(operation_id, operation_num, schema, solrconfig, cql, cor
     with common.fab.settings(fab.show('warnings', 'running', 'stdout', 'stderr'), hosts=node):
         result = execute(fab.run, cmd)
 
-    retrieve_solr_logs(operation_num, configs)
+    local_dir = os.path.join(os.path.expanduser('~'), '.cstar_perf/operation_artifacts')
+    _retrieve_solr_logs(operation_num, configs, local_dir)
     _remove_operation_dir(operation_dir, node)
 
     return result
@@ -408,7 +408,9 @@ def solr_run_benchmark(operation_id, operation_num, testdata, args, node):
     with common.fab.settings(fab.show('warnings', 'running', 'stdout', 'stderr'), hosts=node):
         result = execute(fab.run, cmd)
 
-    retrieve_solr_logs(operation_num, configs)
+    local_dir = os.path.join(os.path.expanduser('~'), '.cstar_perf/operation_artifacts')
+    _retrieve_solr_logs(operation_num, configs, local_dir)
+    execute(common.copy_artifact, local_path=local_dir, remote_path=os.path.join(run_benchmark_path, "exceptions.log"))
     _remove_operation_dir(operation_dir, node)
     return result
 

--- a/tool/cstar_perf/tool/fab_common.py
+++ b/tool/cstar_perf/tool/fab_common.py
@@ -738,6 +738,11 @@ def copy_fincore_logs(local_directory):
     location = os.path.join(local_directory, "fincore.{host}.log".format(host=cfg['hostname']))
     fab.get('/tmp/fincore.stats.log', location)
 
+
+@fab.parallel
+def copy_artifact(local_path, remote_path):
+    fab.get(remote_path, local_path)
+
 @fab.parallel
 def whoami():
     fab.run('whoami')

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -3,7 +3,7 @@ from benchmark import (bootstrap, stress, nodetool, nodetool_multi, cqlsh, bash,
                        start_fincore_capture, stop_fincore_capture, retrieve_fincore_logs,
                        drop_page_cache, wait_for_compaction, setup_stress, clean_stress,
                        get_localhost, retrieve_flamegraph, retrieve_yourkit, dsetool_cmd, dse_cmd, CSTAR_PERF_LOGS_DIR,
-                       solr_create_schema, solr_run_benchmark)
+                       solr_create_schema, solr_run_benchmark, solr_download_geonames)
 from benchmark import config as fab_config, cstar, dse, set_cqlsh_path, set_nodetool_path, spark_cassandra_stress, retrieve_logs_and_create_tarball
 import fab_common as common
 import fab_cassandra as cstar
@@ -29,7 +29,7 @@ logging.basicConfig()
 logger = logging.getLogger('stress_compare')
 logger.setLevel(logging.INFO)
 
-OPERATIONS = ['stress', 'nodetool', 'cqlsh', 'bash', 'ctool', 'spark_cassandra_stress', 'solr_create_schema', 'solr_run_benchmark', 'dse', 'dsetool']
+OPERATIONS = ['stress', 'nodetool', 'cqlsh', 'bash', 'ctool', 'spark_cassandra_stress', 'solr_download_geonames', 'solr_create_schema', 'solr_run_benchmark', 'dse', 'dsetool']
 
 flamegraph.set_common_module(common)
 profiler.set_common_module(common)
@@ -302,6 +302,11 @@ def stress_compare(revisions,
                         output = spark_cassandra_stress(operation['script'], node)
                         stats['output'] = output
                         logger.info("spark_cassandra_stress finished")
+
+                    elif operation['type'] == 'solr_download_geonames':
+                        logger.info("Running solr_download_geonames")
+                        stats['output'] = solr_download_geonames(operation['node'])
+                        logger.info("solr_download_geonames finished")
 
                     elif operation['type'] == 'solr_create_schema':
                         logger.info("Running solr_create_schema")

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -29,18 +29,7 @@ logging.basicConfig()
 logger = logging.getLogger('stress_compare')
 logger.setLevel(logging.INFO)
 
-OPERATIONS = [
-    'stress',
-    'nodetool',
-    'cqlsh',
-    'bash',
-    'ctool',
-    'spark_cassandra_stress',
-    'solr_create_schema',
-    'solr_run_benchmark',
-    'dse',
-    'dsetool'
-]
+OPERATIONS = ['stress', 'nodetool', 'cqlsh', 'bash', 'ctool', 'spark_cassandra_stress', 'solr_create_schema', 'solr_run_benchmark', 'dse', 'dsetool']
 
 flamegraph.set_common_module(common)
 profiler.set_common_module(common)

--- a/tool/cstar_perf/tool/stress_compare.py
+++ b/tool/cstar_perf/tool/stress_compare.py
@@ -306,6 +306,8 @@ def stress_compare(revisions,
                     elif operation['type'] == 'solr_create_schema':
                         logger.info("Running solr_create_schema")
                         stats['output'] = solr_create_schema(
+                            stats['id'],
+                            operation_i,
                             operation['schema'],
                             operation['solrconfig'],
                             operation['cql'],
@@ -317,6 +319,8 @@ def stress_compare(revisions,
                     elif operation['type'] == 'solr_run_benchmark':
                         logger.info("Running solr_run_benchmark")
                         stats['output'] = solr_run_benchmark(
+                            stats['id'],
+                            operation_i,
                             operation['testdata'],
                             operation['args'],
                             operation['node'],


### PR DESCRIPTION
This PR is for adding 2 new operations to enable running solr stress workloads.

Running solr stress really involves two separate operations: 
- creating the schema
- running the stress workload.

To create the schema, a _create-schema.sh_ script is provided with solr stress that takes arguments for providing a custom **schema.xml**, **solrconfig.xml**, **create_table.cql**, and **core** to use. Some pre-defined files are provided or you can upload your own custom ones.

After the schema is created, the main workload is the _run-benchmark.sh_ call. _run-benchmark.sh_ can take a number of arguments, but the **--test-data** argument is a file defining what the test should look like. As with _create-schema.sh_, a number of pre-defined files are provided, or you can provide your own.

To accomplish this workflow, I've added two additional operations:
**solr create-schema.sh** and **solr run-benchmark.sh**

The **solr create-schema.sh** operation has 4 comboboxes for each of the arguments to create-schema.sh. The defaults shown are the ones used if the script is run without arguments. The user can then select one of the provided files, or select the custom option. If custom is selected, the user is provided a textbox to provide their own definition.

The **solr run-benchmark.sh** operation has a similar combobox/textbox layout for selecting the test data file or providing a definition. A separate textbox is provided for the rest of the arguments and is pre-populated with the oft-used arguments and their defaults.
