### PR TITLE
Fix gc stat collection

### DIFF
--- a/tool/cstar_perf/tool/fab_common.py
+++ b/tool/cstar_perf/tool/fab_common.py
@@ -593,6 +593,10 @@ def start():
                                     partitioner=config['partitioner'],
                                     group=config['token_allocation']))
 
+    # Enable nonlocal JMX and set JMX authentication as necessary for collecting GC stats
+    env += 'LOCAL_JMX=no\n'
+    env += 'JVM_EXTRA_OPTS="$JVM_EXTRA_OPTS -Dcom.sun.management.jmxremote.authenticate=false"\n\n'
+
     env_script = "{name}.sh".format(name=uuid.uuid1())
     env_file = StringIO(env)
     fab.run('mkdir -p ~/fab/scripts')

--- a/tool/cstar_perf/tool/fab_common.py
+++ b/tool/cstar_perf/tool/fab_common.py
@@ -564,7 +564,7 @@ def start():
     env += "\n"
     fab.puts('env is: {}'.format(env))
     if not config['use_jna']:
-        env = 'JVM_EXTRA_OPTS=-Dcassandra.boot_without_jna=true\n\n' + env
+        env += 'JVM_EXTRA_OPTS="$JVM_EXTRA_OPTS -Dcassandra.boot_without_jna=true"\n\n'
     # Turn on GC logging:
     fab.run("mkdir -p ~/fab/cassandra/logs")
     log_dir = fab.run("readlink -m {log_dir}".format(log_dir=config['log_dir']))
@@ -579,7 +579,7 @@ def start():
 
     # Flamegraph
     if flamegraph.is_enabled(config):
-        env += "JVM_OPTS=\"$JVM_OPTS -XX:+PreserveFramePointer\""
+        env += "JVM_OPTS=\"$JVM_OPTS -XX:+PreserveFramePointer\"\n"
 
     if profiler.yourkit_is_enabled(config):
         execute(profiler.yourkit_clean)


### PR DESCRIPTION
The first of these 2 commits fixes a couple bugs:

- The changes to `JVM_EXTRA_OPTS` for `use_jna` would be ignored if the user changed `JVM_EXTRA_OPTS` in their passed-in environment script.
- In the flamegraph-enabling code, the line being added to the environment script isn't terminated.

The second commit makes the changes requested in #227. @tjake, could you please review?

@nastra and/or @mshuler, could you please review all the other changes? Thanks.