### PR TITLE
Fix issue when specifying dse.yaml settings

### DIFF
--- a/tool/cstar_perf/tool/fab_common.py
+++ b/tool/cstar_perf/tool/fab_common.py
@@ -418,7 +418,7 @@ def bootstrap(git_fetch=True, revision_override=None, replace_existing_dse_insta
             dse_conf_file = StringIO()
             dse_conf_file.write(yaml.safe_dump(dse_yaml, encoding='utf-8', allow_unicode=True))
             dse_conf_file.seek(0)
-            fab.put(dse_conf_file, dse_yaml_path)
+            fab.put(dse_conf_file, dse_yaml_path.replace('$HOME', '~'))
 
     # Cassandra YAML values can come from two places:
     # 1) Set as options at the top level of the config. This is how


### PR DESCRIPTION
A leftover from https://github.com/datastax/cstar_perf/pull/238

Specifying any settings in the **dse.yaml** field would fail with
````
[node1] put: <file obj> -> $HOME/fab/dse/resources/dse/conf/dse.yaml

Fatal error: put() encountered an exception while uploading '<StringIO.StringIO instance at 0x7ff468ddffc8>'

Underlying exception:
    No such file
````

because **$HOST** needs to be replaced 